### PR TITLE
feat: render Bonanza print PDF from card data (no stored images)

### DIFF
--- a/app/Http/Controllers/PrintBonanzaLootDeckController.php
+++ b/app/Http/Controllers/PrintBonanzaLootDeckController.php
@@ -3,165 +3,32 @@
 namespace App\Http\Controllers;
 
 use App\Models\LootCard;
-use Illuminate\Support\Facades\Storage;
+use Barryvdh\DomPDF\Facade\Pdf;
 
 /**
- * Printer-friendly PDF of the Bonanza Brawl Loot Deck. Composes the stored card
- * images into a cut-grid at tarot size (2.75 × 4.75 in), 4 cards per Letter
- * page. Uses Imagick when available (fast, 300-DPI native); falls back to
- * DomPDF (universally installed) otherwise.
+ * Printer-friendly PDF of the Bonanza Brawl Loot Deck. Renders directly from
+ * the card DATA — no stored images involved. Always current, zero maintenance,
+ * no regeneration step. DomPDF handles the HTML→PDF; the Blade builds a clean
+ * text-based card at tarot size with suit-coloured accents.
  */
 class PrintBonanzaLootDeckController extends Controller
 {
     public function __invoke(): \Illuminate\Http\Response
     {
+        @ini_set('memory_limit', '512M');
+        @set_time_limit(120);
+
         $cards = LootCard::query()
-            ->whereNotNull('image')
+            ->with([
+                'sideAActions.triggers', 'sideBActions.triggers',
+                'sideAAbilities', 'sideBAbilities',
+                'sideATriggers', 'sideBTriggers',
+            ])
             ->orderBy('sort_order')
             ->orderBy('name')
-            ->get(['id', 'slug', 'name', 'image', 'sort_order']);
+            ->get();
 
-        if (extension_loaded('imagick')) {
-            try {
-                return $this->renderWithImagick($cards);
-            } catch (\Throwable) {
-            }
-        }
-
-        return $this->renderWithDomPdf($cards);
-    }
-
-    /**
-     * @param  \Illuminate\Database\Eloquent\Collection<int, LootCard>  $cards
-     */
-    private function renderWithImagick($cards): \Illuminate\Http\Response
-    {
-        @ini_set('memory_limit', '512M');
-        @set_time_limit(120);
-
-        $dpi = 300;
-        $pageW = (int) (8.5 * $dpi);
-        $pageH = (int) (11 * $dpi);
-        $cardW = (int) (2.75 * $dpi);
-        $cardH = (int) (4.75 * $dpi);
-        $cols = 2;
-        $rows = 2;
-        $perPage = $cols * $rows;
-        $gapX = (int) (($pageW - $cols * $cardW) / ($cols + 1));
-        $gapY = (int) (($pageH - $rows * $cardH) / ($rows + 1));
-
-        // Write pages to a temp file instead of accumulating in memory.
-        $tmpFile = tempnam(sys_get_temp_dir(), 'bonanza_').'.pdf';
-
-        $first = true;
-        foreach ($cards->chunk($perPage) as $pageCards) {
-            $page = new \Imagick;
-            $page->newImage($pageW, $pageH, new \ImagickPixel('white'));
-            $page->setImageResolution($dpi, $dpi);
-            $page->setImageFormat('pdf');
-
-            $i = 0;
-            foreach ($pageCards as $card) {
-                $x = $gapX + ($i % $cols) * ($cardW + $gapX);
-                $y = $gapY + intdiv($i, $cols) * ($cardH + $gapY);
-                $i++;
-
-                try {
-                    $blob = Storage::disk('public')->get($card->image);
-                    if (! $blob) {
-                        continue;
-                    }
-                    $img = new \Imagick;
-                    $img->readImageBlob($blob);
-                    unset($blob);
-                    $img->resizeImage($cardW, $cardH, \Imagick::FILTER_LANCZOS, 1);
-                    $page->compositeImage($img, \Imagick::COMPOSITE_OVER, $x, $y);
-                    $img->clear();
-                    $img->destroy();
-                } catch (\Throwable) {
-                }
-
-                $draw = new \ImagickDraw;
-                $draw->setStrokeColor(new \ImagickPixel('#cccccc'));
-                $draw->setStrokeWidth(1);
-                $draw->setFillOpacity(0);
-                $draw->rectangle($x, $y, $x + $cardW, $y + $cardH);
-                $page->drawImage($draw);
-            }
-
-            // Flatten to a single raster layer (frees composite overhead).
-            $page->mergeImageLayers(\Imagick::LAYERMETHOD_FLATTEN);
-            $page->setImageCompression(\Imagick::COMPRESSION_JPEG);
-            $page->setImageCompressionQuality(85);
-
-            if ($first) {
-                $page->writeImage($tmpFile);
-                $first = false;
-            } else {
-                // Append pages to the existing PDF file.
-                $existing = new \Imagick;
-                $existing->readImage($tmpFile);
-                $existing->addImage($page);
-                $existing->writeImages($tmpFile, true);
-                $existing->clear();
-                $existing->destroy();
-            }
-
-            $page->clear();
-            $page->destroy();
-        }
-
-        if (! file_exists($tmpFile) || filesize($tmpFile) === 0) {
-            @unlink($tmpFile);
-            throw new \RuntimeException('Failed to generate PDF');
-        }
-
-        $content = file_get_contents($tmpFile);
-        @unlink($tmpFile);
-
-        return response($content, 200, [
-            'Content-Type' => 'application/pdf',
-            'Content-Disposition' => 'inline; filename="bonanza-loot-deck.pdf"',
-        ]);
-    }
-
-    /**
-     * DomPDF fallback — tiles base64-encoded card images into a simple HTML grid.
-     *
-     * @param  \Illuminate\Database\Eloquent\Collection<int, LootCard>  $cards
-     */
-    private function renderWithDomPdf($cards): \Illuminate\Http\Response
-    {
-        @ini_set('memory_limit', '512M');
-        @set_time_limit(120);
-
-        $html = '<!DOCTYPE html><html><head><meta charset="utf-8"><title>Bonanza Loot Deck</title><style>'
-            .'@page { margin: 0.3in; }'
-            .'* { box-sizing: border-box; }'
-            .'body { margin: 0; }'
-            .'.page { page-break-after: always; }'
-            .'.page:last-child { page-break-after: auto; }'
-            .'.cell { display: inline-block; vertical-align: top; padding: 0.03in; border: 1px dashed #ccc; margin: 0 0.02in 0.04in 0.02in; }'
-            .'.cell img { display: block; width: 2.75in; height: 4.75in; }'
-            .'</style></head><body>';
-
-        foreach ($cards->chunk(4) as $page) {
-            $html .= '<div class="page">';
-            foreach ($page as $card) {
-                $data = Storage::disk('public')->get($card->image);
-                if (! $data) {
-                    continue;
-                }
-                $b64 = base64_encode($data);
-                unset($data);
-                $html .= '<span class="cell"><img src="data:image/png;base64,'.$b64.'" alt="'.e($card->name).'" /></span>';
-                unset($b64);
-            }
-            $html .= '</div>';
-        }
-        $html .= '</body></html>';
-
-        $pdf = \Barryvdh\DomPDF\Facade\Pdf::loadHTML($html)
+        $pdf = Pdf::loadView('PDF.BonanzaDeck', ['cards' => $cards])
             ->setPaper('letter', 'portrait');
 
         return $pdf->stream('bonanza-loot-deck.pdf');

--- a/resources/views/PDF/BonanzaDeck.blade.php
+++ b/resources/views/PDF/BonanzaDeck.blade.php
@@ -1,0 +1,211 @@
+@php
+    $suitColors = [
+        'crow'  => ['border' => '#16a34a', 'bg' => '#dcfce7', 'light' => '#f0fdf4'],
+        'mask'  => ['border' => '#9333ea', 'bg' => '#f3e8ff', 'light' => '#faf5ff'],
+        'ram'   => ['border' => '#dc2626', 'bg' => '#fee2e2', 'light' => '#fef2f2'],
+        'tome'  => ['border' => '#2563eb', 'bg' => '#dbeafe', 'light' => '#eff6ff'],
+        'joker' => ['border' => '#d97706', 'bg' => '#fef3c7', 'light' => '#fffbeb'],
+    ];
+
+    $suitSymbols = [
+        'crow' => "\u{2666}",
+        'mask' => "\u{2663}",
+        'ram'  => "\u{2665}",
+        'tome' => "\u{2660}",
+        'joker' => "\u{2605}",
+    ];
+
+    $cleanText = function (?string $text): string {
+        if (! $text) return '';
+        return trim(preg_replace_callback('/\{\{\s*(\w+)\s*\}\}/', fn ($m) => '(' . ucfirst(strtolower($m[1])) . ')', $text));
+    };
+
+    $statLine = function ($action): string {
+        $parts = [];
+        if (! is_null($action->range)) $parts[] = 'Rng ' . $action->range . ($action->range_type ? ' ' . $action->range_type : '"');
+        if (! is_null($action->stat)) $parts[] = 'Stat ' . $action->stat . ($action->stat_suits ?? '');
+        if (! empty($action->resisted_by)) $parts[] = 'vs ' . $action->resisted_by;
+        if (! is_null($action->target_number)) $parts[] = 'TN ' . $action->target_number . ($action->target_suits ?? '');
+        if (! is_null($action->damage) && $action->damage !== '') $parts[] = 'Dmg ' . $action->damage;
+        return implode(' · ', $parts);
+    };
+@endphp
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <title>Bonanza Loot Deck — Print</title>
+    <style>
+        @page { margin: 0.25in; }
+        * { box-sizing: border-box; margin: 0; padding: 0; }
+        body { font-family: DejaVu Sans, Helvetica, Arial, sans-serif; font-size: 6.5pt; line-height: 1.3; color: #111; }
+
+        .page { page-break-after: always; text-align: center; }
+        .page:last-child { page-break-after: auto; }
+
+        .card {
+            display: inline-block;
+            vertical-align: top;
+            width: 2.75in;
+            height: 4.75in;
+            border: 1.5pt solid #999;
+            border-radius: 6pt;
+            overflow: hidden;
+            text-align: left;
+            margin: 0.04in;
+            position: relative;
+        }
+
+        /* Header + footer: suit-coloured bar */
+        .card-header, .card-footer {
+            padding: 2pt 5pt;
+            font-size: 7.5pt;
+            font-weight: bold;
+            border-bottom: 1pt solid #ccc;
+            overflow: hidden;
+            white-space: nowrap;
+        }
+        .card-footer {
+            border-bottom: none;
+            border-top: 1pt solid #ccc;
+            position: absolute;
+            bottom: 0;
+            left: 0;
+            right: 0;
+        }
+
+        .suit-symbol { font-size: 9pt; margin-right: 2pt; }
+        .card-name { font-size: 7pt; }
+
+        /* Side sections */
+        .side { padding: 3pt 5pt 2pt; }
+        .side-label {
+            display: inline-block;
+            font-size: 6pt;
+            font-weight: bold;
+            text-transform: uppercase;
+            letter-spacing: 0.5pt;
+            padding: 0 3pt;
+            border-radius: 2pt;
+            margin-right: 3pt;
+        }
+        .side-title { font-weight: bold; font-size: 7pt; }
+        .effect { margin-top: 1pt; white-space: pre-line; }
+
+        /* Divider between sides */
+        .divider {
+            text-align: center;
+            padding: 1pt 0;
+            font-size: 7pt;
+            font-weight: bold;
+            border-top: 1pt dashed #ccc;
+            border-bottom: 1pt dashed #ccc;
+        }
+
+        /* Action/ability/trigger blocks */
+        .entity {
+            margin: 2pt 0;
+            padding-left: 4pt;
+            border-left: 1.5pt solid #ccc;
+        }
+        .en-name { font-weight: bold; }
+        .en-stat { font-family: DejaVu Sans Mono, monospace; font-size: 5.5pt; color: #444; }
+        .trigger-line { padding-left: 6pt; font-size: 6pt; }
+
+        /* Side B rotated 180° for the real card feel */
+        .side-b-rotated {
+            transform: rotate(180deg);
+            transform-origin: center center;
+        }
+    </style>
+</head>
+<body>
+@foreach($cards->chunk(4) as $pageCards)
+    <div class="page">
+        @foreach($pageCards as $card)
+            @php
+                $suit = strtolower($card->suit);
+                $colors = $suitColors[$suit] ?? $suitColors['joker'];
+                $symbol = $suitSymbols[$suit] ?? '?';
+                $sides = [
+                    ['letter' => 'A', 'title' => $card->title_a, 'effect' => $card->effect_a,
+                     'abilities' => $card->sideAAbilities, 'actions' => $card->sideAActions, 'triggers' => $card->sideATriggers,
+                     'rotated' => false],
+                    ['letter' => 'B', 'title' => $card->title_b, 'effect' => $card->effect_b,
+                     'abilities' => $card->sideBAbilities, 'actions' => $card->sideBActions, 'triggers' => $card->sideBTriggers,
+                     'rotated' => true],
+                ];
+            @endphp
+            <div class="card" style="border-color: {{ $colors['border'] }}">
+                {{-- Header --}}
+                <div class="card-header" style="background: {{ $colors['bg'] }}; border-color: {{ $colors['border'] }}40">
+                    <span class="suit-symbol" style="color: {{ $colors['border'] }}">{{ $symbol }}</span>
+                    <span>{{ $card->value_label }}</span>
+                    @if($card->name)
+                        <span class="card-name" style="margin-left: 4pt;">{{ $card->name }}</span>
+                    @endif
+                </div>
+
+                @foreach($sides as $idx => $side)
+                    @if($idx === 1)
+                        <div class="divider" style="background: {{ $colors['light'] }}; color: {{ $colors['border'] }}">
+                            {{ $symbol }} {{ $card->value_label }} · {{ ucfirst($suit) }}
+                        </div>
+                    @endif
+
+                    <div class="side{{ $side['rotated'] ? ' side-b-rotated' : '' }}">
+                        <span class="side-label" style="background: {{ $colors['bg'] }}; color: {{ $colors['border'] }}">{{ $side['letter'] }}</span>
+                        @if($side['title'])
+                            <span class="side-title">{{ $side['title'] }}</span>
+                        @endif
+
+                        @if($side['effect'])
+                            <div class="effect">{{ $cleanText($side['effect']) }}</div>
+                        @endif
+
+                        @foreach($side['abilities'] as $ability)
+                            <div class="entity">
+                                <span class="en-name">{{ $ability->name }}@if($ability->costs_stone) (Stone)@endif.</span>
+                                @if($ability->description) {{ $cleanText($ability->description) }}@endif
+                            </div>
+                        @endforeach
+
+                        @foreach($side['actions'] as $action)
+                            <div class="entity">
+                                <span class="en-name">{{ $action->name }}@if($action->stone_cost) [{{ $action->stone_cost }}ss]@endif</span>
+                                @if($statLine($action))
+                                    <span class="en-stat"> — {{ $statLine($action) }}</span>
+                                @endif
+                                @if($action->description)
+                                    <div>{{ $cleanText($action->description) }}</div>
+                                @endif
+                                @foreach($action->triggers as $trigger)
+                                    <div class="trigger-line">
+                                        <span class="en-name">{{ $trigger->name }}</span>@if($trigger->suits) ({{ $trigger->suits }})@endif: {{ $cleanText($trigger->description) }}
+                                    </div>
+                                @endforeach
+                            </div>
+                        @endforeach
+
+                        @foreach($side['triggers'] as $trigger)
+                            <div class="entity">
+                                <span class="en-name">{{ $trigger->name }}</span>@if($trigger->suits) ({{ $trigger->suits }})@endif: {{ $cleanText($trigger->description) }}
+                            </div>
+                        @endforeach
+                    </div>
+                @endforeach
+
+                {{-- Footer (rotated to match Side B orientation) --}}
+                @if($card->name)
+                    <div class="card-footer side-b-rotated" style="background: {{ $colors['bg'] }}; border-color: {{ $colors['border'] }}40">
+                        <span class="suit-symbol" style="color: {{ $colors['border'] }}">{{ $symbol }}</span>
+                        <span>{{ $card->value_label }}</span>
+                        <span class="card-name" style="margin-left: 4pt;">{{ $card->name }}</span>
+                    </div>
+                @endif
+            </div>
+        @endforeach
+    </div>
+@endforeach
+</body>
+</html>

--- a/tests/Feature/Tools/BonanzaPrintTest.php
+++ b/tests/Feature/Tools/BonanzaPrintTest.php
@@ -1,25 +1,26 @@
 <?php
 
+use App\Models\Action;
 use App\Models\LootCard;
-use Illuminate\Support\Facades\Storage;
 
-it('renders the printer-friendly Bonanza loot deck PDF as an image cut-grid', function () {
-    Storage::fake('public');
-    // A minimal valid 1x1 PNG stands in for a captured card image.
-    Storage::disk('public')->put(
-        'loot/test.png',
-        base64_decode('iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==')
-    );
-
-    LootCard::create([
+it('renders the printer-friendly Bonanza loot deck PDF from card data', function () {
+    $card = LootCard::create([
         'slug' => 'test-loot',
         'name' => 'Test Loot',
         'suit' => 'crow',
         'value' => 7,
         'value_label' => '7',
         'sort_order' => 1,
-        'image' => 'loot/test.png',
+        'title_a' => 'Alpha',
+        'effect_a' => 'Gain 1 {{crow}} this turn.',
+        'title_b' => 'Beta',
+        'effect_b' => 'Heal 2.',
     ]);
+
+    $action = Action::factory()->create([
+        'name' => 'Quick Slash', 'stone_cost' => 1, 'range' => 1, 'stat' => 6, 'damage' => '2/3/4',
+    ]);
+    $card->sideAActions()->attach($action->id, ['side' => 'a', 'sort_order' => 0]);
 
     $resp = $this->get(route('tools.bonanza_loot_deck.print'));
 
@@ -28,16 +29,23 @@ it('renders the printer-friendly Bonanza loot deck PDF as an image cut-grid', fu
     expect(strlen($resp->getContent()))->toBeGreaterThan(1000);
 });
 
-it('skips cards without an image and still renders', function () {
+it('renders the print PDF with an empty deck', function () {
+    $this->get(route('tools.bonanza_loot_deck.print'))->assertOk();
+});
+
+it('renders cards without images just fine (no stored image needed)', function () {
     LootCard::create([
-        'slug' => 'no-image',
-        'name' => 'No Image',
+        'slug' => 'no-img',
+        'name' => 'No Image Card',
         'suit' => 'ram',
         'value' => 3,
         'value_label' => '3',
         'sort_order' => 1,
         'image' => null,
+        'effect_a' => 'Test effect.',
     ]);
 
-    $this->get(route('tools.bonanza_loot_deck.print'))->assertOk();
+    $resp = $this->get(route('tools.bonanza_loot_deck.print'));
+    $resp->assertOk();
+    expect($resp->headers->get('content-type'))->toContain('application/pdf');
 });


### PR DESCRIPTION
Replaces the image-tiling approach with server-side rendering from the card database. Eliminates the entire capture → store → regenerate → tile pipeline and all its failure modes (dark mode, stale images, Imagick delegates, memory exhaustion, SSR timeouts).

- DomPDF renders a Blade template with 54 cards at tarot size (2.75×4.75in)
- 4 cards per Letter page, suit-coloured accents (green/purple/red/blue/amber)
- Side B rotated 180° (mirrored) matching the physical card layout
- Actions with stat lines, abilities, triggers rendered inline
- Game-text tokens ({{crow}} etc.) converted to readable text
- Always current from the database — no regeneration needed
- On-screen card images (BonanzaSplitCard captures) stay as-is for the web