### PR TITLE
fix: shrink card text + drop broken Side B rotation

### DIFF
--- a/resources/views/PDF/BonanzaDeck.blade.php
+++ b/resources/views/PDF/BonanzaDeck.blade.php
@@ -8,11 +8,8 @@
     ];
 
     $suitSymbols = [
-        'crow' => "\u{2666}",
-        'mask' => "\u{2663}",
-        'ram'  => "\u{2665}",
-        'tome' => "\u{2660}",
-        'joker' => "\u{2605}",
+        'crow' => "\u{2666}", 'mask' => "\u{2663}",
+        'ram'  => "\u{2665}", 'tome' => "\u{2660}", 'joker' => "\u{2605}",
     ];
 
     $cleanText = function (?string $text): string {
@@ -38,7 +35,7 @@
     <style>
         @page { margin: 0.25in; }
         * { box-sizing: border-box; margin: 0; padding: 0; }
-        body { font-family: DejaVu Sans, Helvetica, Arial, sans-serif; font-size: 6.5pt; line-height: 1.3; color: #111; }
+        body { font-family: DejaVu Sans, Helvetica, Arial, sans-serif; font-size: 5pt; line-height: 1.2; color: #111; }
 
         .page { page-break-after: always; text-align: center; }
         .page:last-child { page-break-after: auto; }
@@ -49,74 +46,56 @@
             width: 2.75in;
             height: 4.75in;
             border: 1.5pt solid #999;
-            border-radius: 6pt;
+            border-radius: 4pt;
             overflow: hidden;
             text-align: left;
-            margin: 0.04in;
-            position: relative;
+            margin: 0.03in;
         }
 
-        /* Header + footer: suit-coloured bar */
-        .card-header, .card-footer {
-            padding: 2pt 5pt;
-            font-size: 7.5pt;
-            font-weight: bold;
-            border-bottom: 1pt solid #ccc;
-            overflow: hidden;
-            white-space: nowrap;
-        }
-        .card-footer {
-            border-bottom: none;
-            border-top: 1pt solid #ccc;
-            position: absolute;
-            bottom: 0;
-            left: 0;
-            right: 0;
-        }
-
-        .suit-symbol { font-size: 9pt; margin-right: 2pt; }
-        .card-name { font-size: 7pt; }
-
-        /* Side sections */
-        .side { padding: 3pt 5pt 2pt; }
-        .side-label {
-            display: inline-block;
+        .card-header {
+            padding: 1.5pt 4pt;
             font-size: 6pt;
             font-weight: bold;
-            text-transform: uppercase;
-            letter-spacing: 0.5pt;
-            padding: 0 3pt;
-            border-radius: 2pt;
-            margin-right: 3pt;
+            border-bottom: 0.75pt solid #ccc;
+            white-space: nowrap;
+            overflow: hidden;
         }
-        .side-title { font-weight: bold; font-size: 7pt; }
+        .suit-sym { font-size: 7pt; margin-right: 1pt; }
+
+        .side {
+            padding: 2pt 4pt 1pt;
+        }
+        .side-lbl {
+            display: inline-block;
+            font-size: 5pt;
+            font-weight: bold;
+            text-transform: uppercase;
+            letter-spacing: 0.3pt;
+            padding: 0 2pt;
+            border-radius: 1pt;
+            margin-right: 2pt;
+        }
+        .side-title { font-weight: bold; font-size: 5.5pt; }
+
         .effect { margin-top: 1pt; white-space: pre-line; }
 
-        /* Divider between sides */
         .divider {
             text-align: center;
             padding: 1pt 0;
-            font-size: 7pt;
+            font-size: 5.5pt;
             font-weight: bold;
-            border-top: 1pt dashed #ccc;
-            border-bottom: 1pt dashed #ccc;
+            border-top: 0.75pt dashed #ccc;
+            border-bottom: 0.75pt dashed #ccc;
         }
 
-        /* Action/ability/trigger blocks */
         .entity {
-            margin: 2pt 0;
-            padding-left: 4pt;
-            border-left: 1.5pt solid #ccc;
+            margin: 1pt 0;
+            padding-left: 3pt;
+            border-left: 1pt solid #ccc;
         }
         .en-name { font-weight: bold; }
-        .en-stat { font-family: DejaVu Sans Mono, monospace; font-size: 5.5pt; color: #444; }
-        .trigger-line { padding-left: 6pt; font-size: 6pt; }
-
-        /* Side B rotated 180° for the real card feel */
-        .side-b-rotated {
-            transform: rotate(180deg);
-            transform-origin: center center;
-        }
+        .en-stat { font-family: DejaVu Sans Mono, monospace; font-size: 4.5pt; color: #444; }
+        .trig-line { padding-left: 5pt; font-size: 4.5pt; }
     </style>
 </head>
 <body>
@@ -129,21 +108,16 @@
                 $symbol = $suitSymbols[$suit] ?? '?';
                 $sides = [
                     ['letter' => 'A', 'title' => $card->title_a, 'effect' => $card->effect_a,
-                     'abilities' => $card->sideAAbilities, 'actions' => $card->sideAActions, 'triggers' => $card->sideATriggers,
-                     'rotated' => false],
+                     'abilities' => $card->sideAAbilities, 'actions' => $card->sideAActions, 'triggers' => $card->sideATriggers],
                     ['letter' => 'B', 'title' => $card->title_b, 'effect' => $card->effect_b,
-                     'abilities' => $card->sideBAbilities, 'actions' => $card->sideBActions, 'triggers' => $card->sideBTriggers,
-                     'rotated' => true],
+                     'abilities' => $card->sideBAbilities, 'actions' => $card->sideBActions, 'triggers' => $card->sideBTriggers],
                 ];
             @endphp
             <div class="card" style="border-color: {{ $colors['border'] }}">
-                {{-- Header --}}
                 <div class="card-header" style="background: {{ $colors['bg'] }}; border-color: {{ $colors['border'] }}40">
-                    <span class="suit-symbol" style="color: {{ $colors['border'] }}">{{ $symbol }}</span>
-                    <span>{{ $card->value_label }}</span>
-                    @if($card->name)
-                        <span class="card-name" style="margin-left: 4pt;">{{ $card->name }}</span>
-                    @endif
+                    <span class="suit-sym" style="color: {{ $colors['border'] }}">{{ $symbol }}</span>
+                    {{ $card->value_label }}
+                    @if($card->name) — {{ $card->name }}@endif
                 </div>
 
                 @foreach($sides as $idx => $side)
@@ -153,11 +127,9 @@
                         </div>
                     @endif
 
-                    <div class="side{{ $side['rotated'] ? ' side-b-rotated' : '' }}">
-                        <span class="side-label" style="background: {{ $colors['bg'] }}; color: {{ $colors['border'] }}">{{ $side['letter'] }}</span>
-                        @if($side['title'])
-                            <span class="side-title">{{ $side['title'] }}</span>
-                        @endif
+                    <div class="side">
+                        <span class="side-lbl" style="background: {{ $colors['bg'] }}; color: {{ $colors['border'] }}">{{ $side['letter'] }}</span>
+                        @if($side['title'])<span class="side-title">{{ $side['title'] }}</span>@endif
 
                         @if($side['effect'])
                             <div class="effect">{{ $cleanText($side['effect']) }}</div>
@@ -173,16 +145,10 @@
                         @foreach($side['actions'] as $action)
                             <div class="entity">
                                 <span class="en-name">{{ $action->name }}@if($action->stone_cost) [{{ $action->stone_cost }}ss]@endif</span>
-                                @if($statLine($action))
-                                    <span class="en-stat"> — {{ $statLine($action) }}</span>
-                                @endif
-                                @if($action->description)
-                                    <div>{{ $cleanText($action->description) }}</div>
-                                @endif
+                                @if($statLine($action))<span class="en-stat"> — {{ $statLine($action) }}</span>@endif
+                                @if($action->description)<div>{{ $cleanText($action->description) }}</div>@endif
                                 @foreach($action->triggers as $trigger)
-                                    <div class="trigger-line">
-                                        <span class="en-name">{{ $trigger->name }}</span>@if($trigger->suits) ({{ $trigger->suits }})@endif: {{ $cleanText($trigger->description) }}
-                                    </div>
+                                    <div class="trig-line"><span class="en-name">{{ $trigger->name }}</span>@if($trigger->suits) ({{ $trigger->suits }})@endif: {{ $cleanText($trigger->description) }}</div>
                                 @endforeach
                             </div>
                         @endforeach
@@ -194,15 +160,6 @@
                         @endforeach
                     </div>
                 @endforeach
-
-                {{-- Footer (rotated to match Side B orientation) --}}
-                @if($card->name)
-                    <div class="card-footer side-b-rotated" style="background: {{ $colors['bg'] }}; border-color: {{ $colors['border'] }}40">
-                        <span class="suit-symbol" style="color: {{ $colors['border'] }}">{{ $symbol }}</span>
-                        <span>{{ $card->value_label }}</span>
-                        <span class="card-name" style="margin-left: 4pt;">{{ $card->name }}</span>
-                    </div>
-                @endif
             </div>
         @endforeach
     </div>


### PR DESCRIPTION
- Body font 5pt (was 6.5), header 6pt (was 7.5), stat lines 4.5pt
- Tighter padding/margins throughout to fit more content per card
- Side B prints right-side-up (DomPDF's rotate was unreliable — broken positioning and overlapping text). Both sides clearly labelled A/B with suit-coloured badges, readable without flipping.