### PR TITLE
Jun 23 tos bonanza batch

### DIFF
--- a/app/Http/Controllers/Game/GameController.php
+++ b/app/Http/Controllers/Game/GameController.php
@@ -835,6 +835,16 @@ class GameController extends Controller
             $crewBuild = $player->crewBuild;
             if ($crewBuild) {
                 $crewBuild->ensureReferences();
+
+                continue;
+            }
+
+            // Bonanza (and other crew-skipped) players have no CrewBuild, so
+            // derive references straight from the fielded models' characters —
+            // otherwise the References panel + token list stay empty.
+            $characterIds = $player->crewMembers->pluck('character_id')->filter()->unique()->values()->all();
+            if (! empty($characterIds)) {
+                $player->setAttribute('references', CrewBuild::computeReferences($characterIds));
             }
         }
     }

--- a/app/Http/Controllers/Game/GameController.php
+++ b/app/Http/Controllers/Game/GameController.php
@@ -957,6 +957,10 @@ class GameController extends Controller
     {
         $characters = Character::standard()
             ->where('is_hidden', false)
+            // Bonanza hires a single non-Leader model — Masters are never
+            // fielded, so they're excluded from the model-select even when
+            // their derived bonanzaCost() lands within the budget.
+            ->where('station', '!=', 'master')
             ->with('miniatures')
             ->orderBy('name')
             ->orderBy('title')

--- a/app/Http/Controllers/TOS/Database/AllegianceController.php
+++ b/app/Http/Controllers/TOS/Database/AllegianceController.php
@@ -304,11 +304,28 @@ class AllegianceController extends Controller
         $total = 0;
         $byRule = [];
         $totalScrip = 0;
+        // Commanders are tallied in their own section and carry an outlier
+        // cost, so they're excluded from the roster average (and not
+        // double-counted under Champion, which every Commander also is).
+        $nonCommanderTotal = 0;
+        $nonCommanderScrip = 0;
 
         foreach ($units as $unit) {
+            $rules = $unit->specialUnitRules ?? collect();
+            $isCommander = $rules->contains(fn ($r) => $r->slug === 'commander');
+
             $total++;
             $totalScrip += (int) ($unit->scrip ?? 0);
-            foreach ($unit->specialUnitRules ?? [] as $rule) {
+
+            if (! $isCommander) {
+                $nonCommanderTotal++;
+                $nonCommanderScrip += (int) ($unit->scrip ?? 0);
+            }
+
+            foreach ($rules as $rule) {
+                if ($isCommander && $rule->slug === 'champion') {
+                    continue;
+                }
                 $key = $rule->slug;
                 if (! isset($byRule[$key])) {
                     $byRule[$key] = ['slug' => $rule->slug, 'name' => $rule->name, 'count' => 0];
@@ -322,7 +339,7 @@ class AllegianceController extends Controller
         return [
             'total' => $total,
             'total_scrip' => $totalScrip,
-            'average_scrip' => $total > 0 ? round($totalScrip / $total, 1) : null,
+            'average_scrip' => $nonCommanderTotal > 0 ? round($nonCommanderScrip / $nonCommanderTotal, 1) : null,
             'by_rule' => $byRule,
         ];
     }

--- a/app/Jobs/GenerateBonanzaLootDeckPdf.php
+++ b/app/Jobs/GenerateBonanzaLootDeckPdf.php
@@ -31,8 +31,13 @@ class GenerateBonanzaLootDeckPdf implements ShouldBeUnique, ShouldQueue
         try {
             $generator->generate();
         } catch (\Throwable $e) {
-            BonanzaDeckPdfStatus::dispatch('failed', message: $e->getMessage());
-            throw $e;
+            // Best-effort cache warming: a render failure must not bubble up
+            // (it would break the card-save request that dispatched this under
+            // a sync queue, and the print route regenerates on demand anyway).
+            report($e);
+            BonanzaDeckPdfStatus::dispatch('failed', null, null, $e->getMessage());
+
+            return;
         }
 
         BonanzaDeckPdfStatus::dispatch('ready', $generator->url(), $generator->generatedAt());

--- a/resources/js/components/TOS/FlipCard.vue
+++ b/resources/js/components/TOS/FlipCard.vue
@@ -75,13 +75,15 @@ function handleKey(e: KeyboardEvent) {
                     />
                 </div>
                 <div class="tos-face absolute inset-0" style="backface-visibility: hidden; transform: rotateY(180deg)">
-                    <CardImage
-                        :src="backImage"
-                        :alt="backAlt"
-                        :allegiance-slug="allegianceSlug"
-                        :placeholder-icon="placeholderIcon"
-                        :aspect-class="aspectClass"
-                    />
+                    <slot name="back">
+                        <CardImage
+                            :src="backImage"
+                            :alt="backAlt"
+                            :allegiance-slug="allegianceSlug"
+                            :placeholder-icon="placeholderIcon"
+                            :aspect-class="aspectClass"
+                        />
+                    </slot>
                 </div>
             </div>
         </div>

--- a/resources/js/pages/Games/Show.vue
+++ b/resources/js/pages/Games/Show.vue
@@ -557,6 +557,13 @@ const postSetup = async (endpoint: string, body: Record<string, unknown>) => {
                 'tokens',
                 'character_upgrades',
                 'all_markers',
+                // Bonanza props are status-gated (populate only at in_progress),
+                // and the master-submit step is what flips Bonanza to in_progress
+                // — so they must reload here or the loot-deck Select button and
+                // crew cards stay empty until a manual refresh.
+                'starting_crews',
+                'loot_card_catalog',
+                'bonanza_crew_upgrades',
             ],
             preserveScroll: true,
             preserveState: true,
@@ -5499,7 +5506,7 @@ const isPastStep = (step: string) => statusOrder.indexOf(props.game.status) > st
                                 </button>
                             </div>
                         </div>
-                        <Button v-if="!isObserver" variant="outline" size="sm" class="mt-2 w-full gap-1 text-xs" @click="openSummonForSlot(1)">
+                        <Button v-if="!isObserver && !isBonanza" variant="outline" size="sm" class="mt-2 w-full gap-1 text-xs" @click="openSummonForSlot(1)">
                             <Plus class="size-3" /> Summon
                         </Button>
                         <!-- Crew References -->
@@ -5945,9 +5952,9 @@ const isPastStep = (step: string) => statusOrder.indexOf(props.game.status) > st
                                 </button>
                             </div>
                         </div>
-                        <!-- Solo: summon for opponent -->
+                        <!-- Solo: summon for opponent (not in Bonanza — solo-vs-loot, no summoning) -->
                         <Button
-                            v-if="isSolo && !isObserver && opponentCrewMembers.length"
+                            v-if="isSolo && !isObserver && !isBonanza && opponentCrewMembers.length"
                             variant="outline"
                             size="sm"
                             class="mt-2 w-full gap-1 text-xs"

--- a/resources/js/pages/Games/Show.vue
+++ b/resources/js/pages/Games/Show.vue
@@ -104,6 +104,14 @@ interface CrewMember {
     game_player_id: number;
 }
 
+interface CrewReferences {
+    version?: number;
+    markers?: Array<{ id: number; name: string; slug?: string; description?: string | null; base?: string | null }>;
+    tokens?: Array<{ id: number; name: string; slug?: string; description?: string | null }>;
+    upgrades?: Array<{ id: number; name: string; slug?: string; front_image?: string | null; back_image?: string | null; type?: string | null }>;
+    characters?: unknown[];
+}
+
 interface GamePlayer {
     id: number;
     slot: number;
@@ -122,7 +130,9 @@ interface GamePlayer {
     is_game_complete: boolean;
     crew_members: CrewMember[];
     master: { id: number; crew_upgrades: any[]; crew_upgrade_mode: string | null } | null;
-    crew_build: { id: number; crew_upgrade_id: number | null } | null;
+    crew_build: { id: number; crew_upgrade_id: number | null; references?: CrewReferences } | null;
+    // Bonanza/crew-skipped players carry server-derived references here instead.
+    references?: CrewReferences;
     active_crew_upgrade_id: number | null;
     crew_upgrade_power_bars: Record<string, number> | null;
     user: { id: number; name: string } | null;
@@ -1136,7 +1146,9 @@ const loadReferences = (target: 'my' | 'opponent') => {
     const refs = target === 'my' ? myReferences : opponentReferences;
     if (refs.value) return;
     const player = target === 'my' ? myPlayer.value : opponent.value;
-    refs.value = player?.crew_build?.references ?? null;
+    // Bonanza/crew-skipped players have no crew_build — the server attaches
+    // derived references directly on the player instead.
+    refs.value = player?.crew_build?.references ?? player?.references ?? null;
 };
 
 const toggleMyRefs = () => loadReferences('my');

--- a/resources/js/pages/TOS/Assets/View.vue
+++ b/resources/js/pages/TOS/Assets/View.vue
@@ -1,12 +1,13 @@
 <script setup lang="ts">
 import PageBanner from '@/components/PageBanner.vue';
 import CardImage from '@/components/TOS/CardImage.vue';
+import FlipCard from '@/components/TOS/FlipCard.vue';
 import TosSuits from '@/components/TosSuits.vue';
 import TosText from '@/components/TosText.vue';
 import { Badge } from '@/components/ui/badge';
 import { Card, CardContent } from '@/components/ui/card';
 import { Head, Link } from '@inertiajs/vue3';
-import { ArrowLeft, Package, Swords } from 'lucide-vue-next';
+import { ArrowLeft, Ban, Package, Swords } from 'lucide-vue-next';
 
 interface Limit {
     id: number;
@@ -94,7 +95,27 @@ const describeLimit = (l: Limit): string => {
 
             <Card class="overflow-hidden">
                 <div class="grid gap-4 p-4 lg:grid-cols-[minmax(0,260px)_1fr]">
+                    <!-- Disable-able Assets flip to a Disabled backside (placeholder art for now). -->
+                    <FlipCard
+                        v-if="asset.disable_count != null"
+                        :front-image="asset.image_path"
+                        :front-alt="asset.name"
+                        :back-alt="`${asset.name} (Disabled)`"
+                        :allegiance-slug="asset.allegiances[0]?.slug ?? null"
+                        :placeholder-icon="Package"
+                    >
+                        <template #back>
+                            <div
+                                class="flex aspect-[5/7] w-full flex-col items-center justify-center gap-2 rounded-xl border-2 border-dashed border-muted-foreground/30 bg-muted/40 text-muted-foreground"
+                            >
+                                <Ban class="size-10 opacity-40" />
+                                <span class="text-sm font-bold uppercase tracking-wider">Disabled</span>
+                                <span class="px-4 text-center text-[10px] opacity-70">Backside art coming soon</span>
+                            </div>
+                        </template>
+                    </FlipCard>
                     <CardImage
+                        v-else
                         :src="asset.image_path"
                         :alt="asset.name"
                         :allegiance-slug="asset.allegiances[0]?.slug ?? null"

--- a/tests/Feature/Games/BonanzaBrawlTest.php
+++ b/tests/Feature/Games/BonanzaBrawlTest.php
@@ -10,6 +10,7 @@ use App\Models\GamePlayer;
 use App\Models\Miniature;
 use App\Models\Scheme;
 use App\Models\Strategy;
+use App\Models\Token;
 use App\Models\User;
 
 beforeEach(function () {
@@ -188,6 +189,59 @@ it('lets a Bonanza player pick a non-master character (any station) of their fac
     ])->assertOk();
 
     expect(GamePlayer::where('game_id', $game->id)->where('slot', 1)->first()->master_id)->toBe($enforcer->id);
+});
+
+it('excludes Masters from the Bonanza model-select prop', function () {
+    $creator = User::factory()->create();
+    $game = Game::factory()->bonanza()->create([
+        'creator_id' => $creator->id,
+        'is_solo' => true,
+        'status' => GameStatusEnum::MasterSelect,
+    ]);
+    GamePlayer::factory()->for($game, 'game')->create(['user_id' => $creator->id, 'slot' => 1, 'faction' => 'arcanists']);
+
+    // A Master (cost null → bonanzaCost caps at 10, so it WOULD clear the cost
+    // filter) plus a minion. Only the non-Leader minion should be offered.
+    $master = Character::factory()->create(['station' => 'master', 'faction' => 'arcanists', 'name' => 'Rasputina', 'display_name' => 'Rasputina', 'cost' => null, 'health' => 8]);
+    Miniature::factory()->for($master, 'character')->create();
+    $minion = Character::factory()->create(['station' => 'minion', 'faction' => 'arcanists', 'name' => 'Ice Gamin', 'display_name' => 'Ice Gamin', 'cost' => 4]);
+    Miniature::factory()->for($minion, 'character')->create();
+
+    $this->actingAs($creator)->get(route('games.show', $game->uuid))
+        ->assertOk()
+        ->assertInertia(fn ($page) => $page->where('masters', function ($masters) {
+            $names = collect($masters)->pluck('name');
+
+            return ! $names->contains('Rasputina') && $names->contains('Ice Gamin');
+        }));
+});
+
+it('derives References (with tokens) for the Bonanza model that has no crew build', function () {
+    $creator = User::factory()->create();
+    $game = Game::factory()->bonanza()->create([
+        'creator_id' => $creator->id,
+        'is_solo' => true,
+        'status' => GameStatusEnum::MasterSelect,
+    ]);
+
+    $model = Character::factory()->create(['station' => 'minion', 'faction' => 'arcanists', 'name' => 'Ice Golem', 'display_name' => 'Ice Golem', 'cost' => 8]);
+    Miniature::factory()->for($model, 'character')->create();
+    $token = Token::factory()->create(['name' => 'Frozen Heart']);
+    $model->tokens()->attach($token->id);
+
+    GamePlayer::factory()->for($game, 'game')->create(['user_id' => $creator->id, 'slot' => 1, 'faction' => 'arcanists']);
+    GamePlayer::factory()->for($game, 'game')->create(['user_id' => null, 'slot' => 2, 'opponent_name' => 'Opp']);
+
+    $this->actingAs($creator)->postJson(route('games.setup.master', $game->uuid), ['master_name' => 'Ice Golem'])->assertOk();
+
+    $this->actingAs($creator)->get(route('games.show', $game->uuid))
+        ->assertOk()
+        ->assertInertia(fn ($page) => $page->where('game.players', function ($players) {
+            $slotOne = collect($players)->firstWhere('slot', 1);
+            $tokens = collect($slotOne['references']['tokens'] ?? []);
+
+            return $tokens->contains('name', 'Frozen Heart');
+        }));
 });
 
 it('derives effective Bonanza cost for dash-cost models', function () {

--- a/tests/Feature/TOS/AllegianceControllerTest.php
+++ b/tests/Feature/TOS/AllegianceControllerTest.php
@@ -1,6 +1,8 @@
 <?php
 
 use App\Models\TOS\Allegiance;
+use App\Models\TOS\SpecialUnitRule;
+use App\Models\TOS\Unit;
 
 it('renders the TOS landing hub', function () {
     $earth = Allegiance::factory()->earth()->create(['name' => 'King\'s Empire']);
@@ -69,4 +71,36 @@ it('renders the Earth-side type page pooling units across all Earth allegiances 
 
 it('returns 404 for an invalid type slug', function () {
     $this->get(route('tos.allegiances.viewByType', 'made-up'))->assertNotFound();
+});
+
+it('averages roster scrip excluding Commanders and does not count them as Champions', function () {
+    $a = Allegiance::factory()->create(['slug' => 'guild', 'name' => 'Guild']);
+    $commander = SpecialUnitRule::factory()->create(['slug' => 'commander', 'name' => 'Commander']);
+    $champion = SpecialUnitRule::factory()->create(['slug' => 'champion', 'name' => 'Champion']);
+
+    // Rank-and-file: 3, 3, 4, 6 → average 4. The scrip-6 one is a (non-commander) Champion.
+    foreach ([3, 3, 4] as $scrip) {
+        Unit::factory()->withSides()->create(['scrip' => $scrip])->allegiances()->sync([$a->id]);
+    }
+    $champUnit = Unit::factory()->withSides()->create(['scrip' => 6]);
+    $champUnit->allegiances()->sync([$a->id]);
+    $champUnit->specialUnitRules()->sync([$champion->id]);
+
+    // Commander (also a Champion by the rules), outlier scrip 18.
+    $cmdr = Unit::factory()->withSides()->create(['scrip' => 18]);
+    $cmdr->allegiances()->sync([$a->id]);
+    $cmdr->specialUnitRules()->sync([$commander->id, $champion->id]);
+
+    $this->get(route('tos.allegiances.view', $a->slug))
+        ->assertOk()
+        ->assertInertia(fn ($page) => $page
+            ->where('statistics.total', 5)
+            ->where('statistics.average_scrip', fn ($v) => (float) $v === 4.0)
+            ->where('statistics.by_rule', function ($rules) {
+                $rules = collect($rules);
+
+                return $rules->firstWhere('slug', 'commander')['count'] === 1
+                    && $rules->firstWhere('slug', 'champion')['count'] === 1; // commander excluded
+            })
+        );
 });


### PR DESCRIPTION
TOS + Bonanza feedback batch (Jun 23)
Bonanza Game Tracker
- Exclude Masters from the model-select (fields a single non-Leader model)
- Loot-deck Select button + crew cards ready on game start (status-gated props now reload on master-submit)
- Hide the Summon button in Bonanza (solo-vs-loot)
- Derive crew References (tokens/markers/upgrades) for the lone model with no crew build
- Fixes a regression from #225 — the deck-PDF job threw on a named param + re-threw render failures, breaking every loot-card save under the test queue (un-reds main)

TOS database
- Allegiance average scrip + Champion count exclude Commanders
- Disable-able Assets flip to a Disabled backside (placeholder art for now; FlipCard gained a #back slot)