### PR TITLE
fix(tracker): drop end-of-activation tokens when a model activates

### DIFF
--- a/app/Http/Controllers/Game/GamePlayController.php
+++ b/app/Http/Controllers/Game/GamePlayController.php
@@ -100,11 +100,29 @@ class GamePlayController extends Controller
             }
         }
 
+        // "Until end of activation" tokens fall off the moment a model is
+        // activated for the turn. Strip them on the false → true transition and
+        // report them so the client can reflect the removal without a reload.
+        $removedTokens = [];
+        if (! empty($validated['is_activated']) && ! $gameCrewMember->is_activated) {
+            $endOfActivationIds = Token::where('removal_timing', TokenRemovalTimingEnum::EndOfActivation)->pluck('id');
+            if ($endOfActivationIds->isNotEmpty()) {
+                $source = array_key_exists('attached_tokens', $validated)
+                    ? $validated['attached_tokens']
+                    : ($gameCrewMember->attached_tokens ?? []);
+                [$keep, $drop] = collect($source)->partition(fn ($t) => ! $endOfActivationIds->contains($t['id'] ?? null));
+                if ($drop->isNotEmpty()) {
+                    $validated['attached_tokens'] = $keep->values()->all();
+                    $removedTokens = $drop->map(fn ($t) => ['id' => (int) ($t['id'] ?? 0), 'name' => $t['name'] ?? ''])->values()->all();
+                }
+            }
+        }
+
         $gameCrewMember->update($validated);
 
         $this->broadcastToOpponents($game, new GameCrewMemberUpdated($game, 'updated'));
 
-        return response()->json(['success' => true]);
+        return response()->json(['success' => true, 'removed_tokens' => $removedTokens]);
     }
 
     /**

--- a/resources/js/pages/Games/Show.vue
+++ b/resources/js/pages/Games/Show.vue
@@ -1534,12 +1534,21 @@ const toggleActivated = async (member: any) => {
     const oldValue = member.is_activated;
     // Optimistic update for instant UI feedback
     member.is_activated = !member.is_activated;
-    const res = await gameApi.patch(route('games.play.crew.update', { game: props.game.uuid, gameCrewMember: member.id }), {
-        is_activated: member.is_activated,
-    });
+    const res = await gameApi.patch<{ removed_tokens?: { id: number; name: string }[] }>(
+        route('games.play.crew.update', { game: props.game.uuid, gameCrewMember: member.id }),
+        { is_activated: member.is_activated },
+    );
     if (!res.ok) {
         member.is_activated = oldValue;
         router.reload({ only: ['game'], preserveScroll: true });
+        return;
+    }
+    // End-of-activation tokens fall off as the model activates — reflect the
+    // server's removal locally so they disappear without a reload.
+    const removed = res.data.removed_tokens ?? [];
+    if (removed.length) {
+        const removedIds = new Set(removed.map((t) => t.id));
+        member.attached_tokens = (member.attached_tokens ?? []).filter((t: any) => !removedIds.has(t.id));
     }
 };
 

--- a/tests/Feature/Games/EndOfActivationTokenTest.php
+++ b/tests/Feature/Games/EndOfActivationTokenTest.php
@@ -1,0 +1,63 @@
+<?php
+
+use App\Enums\TokenRemovalTimingEnum;
+use App\Models\Game;
+use App\Models\GameCrewMember;
+use App\Models\GamePlayer;
+use App\Models\Token;
+use App\Models\User;
+
+/**
+ * @return array{0: User, 1: Game, 2: GameCrewMember, 3: Token, 4: Token}
+ */
+function endOfActivationFixture(bool $alreadyActivated = false): array
+{
+    $focus = Token::factory()->create(['name' => 'Focus', 'removal_timing' => TokenRemovalTimingEnum::EndOfActivation]);
+    $burning = Token::factory()->create(['name' => 'Burning']); // persists (null timing)
+
+    $user = User::factory()->create();
+    $game = Game::factory()->bonanza()->inProgress()->create(['creator_id' => $user->id]);
+    $player = GamePlayer::factory()->for($game, 'game')->create(['user_id' => $user->id, 'slot' => 1]);
+    $member = GameCrewMember::factory()->create([
+        'game_id' => $game->id,
+        'game_player_id' => $player->id,
+        'is_activated' => $alreadyActivated,
+        'attached_tokens' => [['id' => $focus->id, 'name' => 'Focus'], ['id' => $burning->id, 'name' => 'Burning']],
+    ]);
+
+    return [$user, $game, $member, $focus, $burning];
+}
+
+it('drops end-of-activation tokens when a model is activated and reports them', function () {
+    [$user, $game, $member, $focus] = endOfActivationFixture();
+
+    $resp = $this->actingAs($user)
+        ->patchJson(route('games.play.crew.update', ['game' => $game->uuid, 'gameCrewMember' => $member->id]), ['is_activated' => true])
+        ->assertOk();
+
+    $names = collect($member->fresh()->attached_tokens)->pluck('name');
+    expect($names)->toContain('Burning')->not->toContain('Focus');
+    $resp->assertJsonPath('removed_tokens.0.id', $focus->id)
+        ->assertJsonPath('removed_tokens.0.name', 'Focus');
+});
+
+it('does not drop end-of-activation tokens when de-activating', function () {
+    [$user, $game, $member] = endOfActivationFixture(alreadyActivated: true);
+
+    $this->actingAs($user)
+        ->patchJson(route('games.play.crew.update', ['game' => $game->uuid, 'gameCrewMember' => $member->id]), ['is_activated' => false])
+        ->assertOk()
+        ->assertJsonPath('removed_tokens', []);
+
+    expect(collect($member->fresh()->attached_tokens)->pluck('name'))->toContain('Focus');
+});
+
+it('leaves persistent tokens alone on activation', function () {
+    [$user, $game, $member, , $burning] = endOfActivationFixture();
+
+    $this->actingAs($user)
+        ->patchJson(route('games.play.crew.update', ['game' => $game->uuid, 'gameCrewMember' => $member->id]), ['is_activated' => true])
+        ->assertOk();
+
+    expect(collect($member->fresh()->attached_tokens)->pluck('id'))->toContain($burning->id);
+});


### PR DESCRIPTION
End-of-activation tokens never fell off — only end-of-turn removal was wired up. Now updateCrewMember strips a member's `end_of_activation` tokens on the is_activated false → true transition and returns them, and the client's toggleActivated reflects the removal locally (no reload needed). A token added while a model is already activated is left until its next activation, matching the rule that the check happens as activation is clicked.