### PR TITLE
fix(campaign): correct Edit Leader route + advance-leader tag fallback

### DIFF
--- a/resources/js/pages/Campaigns/Aftermath.vue
+++ b/resources/js/pages/Campaigns/Aftermath.vue
@@ -640,11 +640,13 @@ const finalize = () => router.post(route('campaigns.aftermaths.finalize', props.
                             <Checkbox checked disabled />
                             <span>+1 for playing the game (always)</span>
                         </label>
-                        <label v-if="xp_track?.tag === 'bruiser'" class="flex items-start gap-2">
+                        <!-- Show the option matching the leader's tag; if the tag is
+                             unknown (older leader / not set), fall back to both. -->
+                        <label v-if="!xp_track?.tag || xp_track.tag === 'bruiser'" class="flex items-start gap-2">
                             <Checkbox :checked="xpForm.bruiser_killed" @update:checked="(v: boolean) => (xpForm.bruiser_killed = v)" />
                             <span>+1 Bruiser killed a non-peon enemy</span>
                         </label>
-                        <label v-if="xp_track?.tag === 'strategist'" class="flex items-start gap-2">
+                        <label v-if="!xp_track?.tag || xp_track.tag === 'strategist'" class="flex items-start gap-2">
                             <Checkbox :checked="xpForm.strategist_interacted" @update:checked="(v: boolean) => (xpForm.strategist_interacted = v)" />
                             <span>+1 Strategist Interacted in enemy DZ</span>
                         </label>

--- a/resources/js/pages/Campaigns/ArsenalSheet.vue
+++ b/resources/js/pages/Campaigns/ArsenalSheet.vue
@@ -354,7 +354,7 @@ const totemRendererProps = computed(() => {
                 <Button size="sm" variant="outline" @click="copyShareLink"> <Copy class="mr-1 h-3 w-3" /> Share </Button>
                 <!-- Full editing (incl. action details) happens in the card editor —
                      the campaign builder can't change an action's stats/triggers. -->
-                <Link v-if="view_mode.is_owner && leader" :href="route('card_creator.edit', leader.id)">
+                <Link v-if="view_mode.is_owner && leader" :href="route('tools.card_creator.edit', leader.id)">
                     <Button size="sm">Edit Leader</Button>
                 </Link>
                 <Button v-if="view_mode.is_owner && leader" size="sm" variant="destructive" @click="annihilateLeader"> Annihilate </Button>


### PR DESCRIPTION
Two QA regressions from the round-2 batch:

- Arsenal Sheet rendered a blank page (no 500) — `route('card_creator.edit')` is not a real Ziggy route name (it's `tools.card_creator.edit`), so the Ziggy "route not found" error crashed the whole Vue render (SSR + client).
- Advance Leader showed neither the Bruiser nor Strategist XP option for a leader whose tag isn't set — the strict tag gating hid both. Now falls back to showing both when the tag is unknown, while still showing only the matching one for a properly-tagged leader.