### PR TITLE
feat(campaign): log Leadership advancements from the Arsenal Sheet

### DIFF
--- a/app/Http/Controllers/Campaign/ArsenalSheetController.php
+++ b/app/Http/Controllers/Campaign/ArsenalSheetController.php
@@ -6,9 +6,11 @@ use App\Http\Controllers\Controller;
 use App\Models\Campaign\Campaign;
 use App\Models\Campaign\CampaignCrew;
 use App\Models\Campaign\CampaignEquipment;
+use App\Models\Campaign\CampaignLeaderAdvancement;
 use App\Models\Campaign\LuckyMiss;
 use App\Models\CustomCharacter;
 use App\Services\CampaignRules;
+use App\Support\Campaign\AftermathCatalog;
 use Illuminate\Http\Request;
 
 /**
@@ -117,6 +119,25 @@ class ArsenalSheetController extends Controller
             // from logged-game XP via the Aftermath flow. Falls back to the
             // empty canonical layout so a freshly built leader still renders.
             'leader_xp_track' => $leader ? ($leader->xp_track ?? CustomCharacter::defaultXpTrack()) : null,
+            // Advancements already logged against this leader, keyed for display
+            // against the catalog (resolved to names client-side).
+            'leader_advancements' => $leader
+                ? CampaignLeaderAdvancement::query()
+                    ->where('custom_character_id', $leader->id)
+                    ->orderBy('position_in_xp_track')
+                    ->get()
+                    ->map(fn (CampaignLeaderAdvancement $a) => [
+                        'id' => $a->id,
+                        'position_in_xp_track' => $a->position_in_xp_track,
+                        'source_table' => $a->source_table->value,
+                        'catalog_id' => $a->catalog_core_id,
+                        'free_choice' => $a->free_choice,
+                    ])
+                : [],
+            // Advancement-table catalogs (same source the Aftermath uses) — used
+            // to resolve taken-advancement names for everyone and to drive the
+            // owner's pick-an-advancement UI.
+            'advancement_catalogs' => $leader ? AftermathCatalog::advancementCatalogs() : null,
             'totem' => $totem,
             // The crew's earned equipment (pg 20 Barter) — attachable to any
             // model when hiring. Shown on the arsenal sheet below the models.

--- a/app/Http/Controllers/Campaign/CampaignAftermathController.php
+++ b/app/Http/Controllers/Campaign/CampaignAftermathController.php
@@ -16,11 +16,10 @@ use App\Models\Campaign\CampaignArsenalModel;
 use App\Models\Campaign\CampaignCrew;
 use App\Models\Campaign\CampaignEquipment;
 use App\Models\Campaign\CampaignGame;
-use App\Models\Campaign\CampaignLeaderAdvancement;
 use App\Models\Campaign\LuckyMiss;
 use App\Models\CustomCharacter;
-use App\Models\Trigger;
 use App\Models\Upgrade;
+use App\Services\Campaign\LeaderAdvancementService;
 use App\Services\CampaignRules;
 use App\Support\Campaign\AftermathCatalog;
 use App\Traits\Campaign\AuthorizesCampaignAccess;
@@ -615,12 +614,13 @@ class CampaignAftermathController extends Controller
 
         // Rule enforcement before we mutate state. Reject the batch if any
         // advancement violates a rule — better than partial application.
-        $rejection = $this->validateAdvancementRules($aftermath, $leader, $data['advancements'] ?? []);
+        $advancementService = app(LeaderAdvancementService::class);
+        $rejection = $advancementService->validate($leader, $data['advancements'] ?? []);
         if ($rejection !== null) {
             return redirect()->back()->withMessage($rejection, null, MessageTypeEnum::error);
         }
 
-        $advanced = $this->lockAndAdvance($aftermath, 4, function (CampaignAftermath $locked) use ($leader, $data, $xpEarned) {
+        $advanced = $this->lockAndAdvance($aftermath, 4, function (CampaignAftermath $locked) use ($leader, $data, $xpEarned, $advancementService) {
             // Lazy-init the XP track to the canonical 39-box layout the first
             // time we touch it.
             $track = $leader->xp_track ?? CustomCharacter::defaultXpTrack();
@@ -636,22 +636,7 @@ class CampaignAftermathController extends Controller
             }
             $leader->update(['xp_track' => $track]);
 
-            foreach (($data['advancements'] ?? []) as $a) {
-                CampaignLeaderAdvancement::create([
-                    'custom_character_id' => $leader->id,
-                    'source_aftermath_id' => $locked->id,
-                    'source_table' => $a['source_table'],
-                    // Post-consolidation FK to core tables (upgrades / actions /
-                    // triggers / abilities / custom_characters depending on
-                    // source_table). Legacy catalog_id stays null on new rows.
-                    'catalog_core_id' => $a['catalog_id'] ?? null,
-                    'from_equipment_id' => $a['from_equipment_id'] ?? null,
-                    'applied_to_action_index' => $a['applied_to_action_index'] ?? -1,
-                    'position_in_xp_track' => $a['position_in_xp_track'],
-                    'free_choice' => $a['free_choice'] ?? null,
-                    'acquired_at' => now(),
-                ]);
-            }
+            $advancementService->create($leader, $data['advancements'] ?? [], $locked->id);
 
             $locked->update(['current_phase' => 5]);
         });
@@ -825,112 +810,6 @@ class CampaignAftermathController extends Controller
             ->whereIn('character_id', $killedCharacterIds)
             ->with('character:id,display_name,station,faction')
             ->get(['id', 'campaign_crew_id', 'character_id', 'label']);
-    }
-
-    /**
-     * Rule-validation for Phase 4 advancement picks. Returns null if all are
-     * valid, or an error-message string on the first violation.
-     *
-     * Enforces:
-     * - Tier ≤ the number in the XP box being filled (pg 31): a tier-N table can
-     *   only be chosen at a box showing N or higher.
-     * - Summoning advancement is at most once per CAMPAIGN (pg 54).
-     * - Totem advancement is only available while the crew has no totem, and
-     *   requires an EXACT flip-value match against the chosen template (pg 52).
-     * - Flip-and-choose tables (Attack/Tactical Mod, Action, Ability) cap the
-     *   chosen option's value at the flipped card "or lower" (pg 38-50). Checked
-     *   only when the client supplies the flipped value.
-     *
-     * @param  array<int, array<string, mixed>>  $advancements
-     */
-    private function validateAdvancementRules(CampaignAftermath $aftermath, CustomCharacter $leader, array $advancements): ?string
-    {
-        // XP-track box tiers keyed by index — the box reached caps tier (pg 31).
-        $track = $leader->xp_track ?? CustomCharacter::defaultXpTrack();
-        $boxTierByIndex = [];
-        foreach ($track as $box) {
-            $boxTierByIndex[$box['index']] = $box['tier'] ?? null;
-        }
-
-        $crewHasTotem = CustomCharacter::query()
-            ->where('campaign_crew_id', $leader->campaign_crew_id)
-            ->where('is_campaign_totem', true)
-            ->where('current', true)
-            ->exists();
-
-        $sawSummoning = false;
-        foreach ($advancements as $a) {
-            $table = AdvancementTableEnum::tryFrom((string) ($a['source_table'] ?? ''));
-            if (! $table) {
-                return 'Unknown advancement table.';
-            }
-
-            // Tier gate against the XP box being filled.
-            $position = $a['position_in_xp_track'] ?? null;
-            $boxTier = $position !== null ? ($boxTierByIndex[$position] ?? null) : null;
-            if ($boxTier === null) {
-                return 'That experience box does not grant an advancement.';
-            }
-            if ($table->tier() > $boxTier) {
-                return "A tier {$table->tier()} advancement cannot be taken at a tier {$boxTier} experience box.";
-            }
-
-            if ($table === AdvancementTableEnum::Summoning) {
-                if ($sawSummoning) {
-                    return 'Summoning Advancement may only be selected once.';
-                }
-                $sawSummoning = true;
-
-                // Campaign-wide check across every prior aftermath on this leader.
-                $existing = CampaignLeaderAdvancement::query()
-                    ->where('custom_character_id', $leader->id)
-                    ->where('source_table', AdvancementTableEnum::Summoning)
-                    ->exists();
-                if ($existing) {
-                    return 'Summoning Advancement has already been used in this campaign.';
-                }
-            }
-
-            if ($table === AdvancementTableEnum::Totem) {
-                if ($crewHasTotem) {
-                    return 'Totem Advancement is only available while the crew has no totem.';
-                }
-
-                $catalogId = $a['catalog_id'] ?? null;
-                $flipValue = $a['flip_value'] ?? null;
-                if ($catalogId === null || $flipValue === null) {
-                    return 'Totem Advancement requires both a totem choice and the flipped value.';
-                }
-                $template = CustomCharacter::query()
-                    ->where('is_campaign_totem_template', true)
-                    ->whereKey($catalogId)
-                    ->first();
-                if (! $template) {
-                    return 'Selected Totem is not a recognized template.';
-                }
-                if ((int) $template->campaign_totem_flip_value !== (int) $flipValue) {
-                    return 'Totem Advancement requires an exact flip-value match — chosen totem does not match the flip.';
-                }
-            }
-
-            // Flip-and-choose ceiling. Each table's catalog row carries its own
-            // campaign_flip_value; the chosen option must be ≤ the flipped card.
-            $catalogId = $a['catalog_id'] ?? null;
-            $flip = $a['flip_value'] ?? null;
-            if ($catalogId !== null && $flip !== null) {
-                $rowFlip = match ($table) {
-                    AdvancementTableEnum::AttackMod, AdvancementTableEnum::TacticalMod => Trigger::query()->whereKey($catalogId)->value('campaign_flip_value'),
-                    AdvancementTableEnum::Action => Action::query()->whereKey($catalogId)->value('campaign_flip_value'),
-                    AdvancementTableEnum::Ability => Ability::query()->whereKey($catalogId)->value('campaign_flip_value'),
-                    default => null,
-                };
-                if ($rowFlip !== null && (int) $rowFlip > (int) $flip) {
-                    return "That advancement needs a flip of {$rowFlip} or higher — your flip was {$flip}.";
-                }
-            }
-        }
-
-        return null;
     }
 
     private function loadXpTrackForCrew(CampaignAftermath $aftermath): ?array

--- a/app/Http/Controllers/Campaign/LeaderAdvancementController.php
+++ b/app/Http/Controllers/Campaign/LeaderAdvancementController.php
@@ -1,0 +1,85 @@
+<?php
+
+namespace App\Http\Controllers\Campaign;
+
+use App\Enums\MessageTypeEnum;
+use App\Http\Controllers\Controller;
+use App\Http\Requests\Campaign\StoreLeaderAdvancementRequest;
+use App\Models\Campaign\Campaign;
+use App\Models\Campaign\CampaignCrew;
+use App\Models\Campaign\CampaignLeaderAdvancement;
+use App\Models\CustomCharacter;
+use App\Services\Campaign\LeaderAdvancementService;
+use App\Traits\Campaign\AuthorizesCampaignAccess;
+use Illuminate\Http\Request;
+
+/**
+ * Log / remove a Leadership-Experience advancement against the crew's leader
+ * straight from the Arsenal Sheet (pg 31). Advancements are also taken during
+ * the Aftermath's Advance-Leader step; both go through LeaderAdvancementService
+ * so the rules + record shape stay identical.
+ */
+class LeaderAdvancementController extends Controller
+{
+    use AuthorizesCampaignAccess;
+
+    public function store(StoreLeaderAdvancementRequest $request, Campaign $campaign, CampaignCrew $crew, LeaderAdvancementService $service)
+    {
+        $this->ensureCrewOwner($request, $campaign, $crew);
+
+        $leader = $this->currentLeader($crew);
+        if (! $leader) {
+            return redirect()->back()->withMessage('No active leader to advance — build one first.', null, MessageTypeEnum::error);
+        }
+
+        $data = $request->validated();
+        $position = (int) $data['position_in_xp_track'];
+
+        // The box must be earned (filled) and grant an advancement (numbered tier),
+        // and not already hold one — pick a different box or remove it first.
+        $box = collect($leader->xp_track ?? CustomCharacter::defaultXpTrack())->firstWhere('index', $position);
+        if (! $box || empty($box['filled']) || ($box['tier'] ?? null) === null) {
+            return redirect()->back()->withMessage('That experience box has not been earned yet, or grants no advancement.', null, MessageTypeEnum::error);
+        }
+        $alreadyTaken = CampaignLeaderAdvancement::query()
+            ->where('custom_character_id', $leader->id)
+            ->where('position_in_xp_track', $position)
+            ->exists();
+        if ($alreadyTaken) {
+            return redirect()->back()->withMessage('That box already has an advancement — remove it first to change it.', null, MessageTypeEnum::error);
+        }
+
+        $rejection = $service->validate($leader, [$data]);
+        if ($rejection !== null) {
+            return redirect()->back()->withMessage($rejection, null, MessageTypeEnum::error);
+        }
+
+        // source_aftermath_id is null — this was logged directly, not via an aftermath.
+        $service->create($leader, [$data], null);
+
+        return redirect()->back()->withMessage('Advancement logged.');
+    }
+
+    public function destroy(Request $request, Campaign $campaign, CampaignCrew $crew, CampaignLeaderAdvancement $advancement)
+    {
+        $this->ensureCrewOwner($request, $campaign, $crew);
+
+        $leader = $this->currentLeader($crew);
+        if (! $leader || $advancement->custom_character_id !== $leader->id) {
+            abort(403);
+        }
+
+        $advancement->delete();
+
+        return redirect()->back()->withMessage('Advancement removed.');
+    }
+
+    private function currentLeader(CampaignCrew $crew): ?CustomCharacter
+    {
+        return CustomCharacter::query()
+            ->where('campaign_crew_id', $crew->id)
+            ->where('is_campaign_leader', true)
+            ->where('current', true)
+            ->first();
+    }
+}

--- a/app/Http/Requests/Campaign/StoreLeaderAdvancementRequest.php
+++ b/app/Http/Requests/Campaign/StoreLeaderAdvancementRequest.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace App\Http\Requests\Campaign;
+
+use App\Enums\Campaign\AdvancementTableEnum;
+use App\Models\Campaign\Campaign;
+use App\Models\Campaign\CampaignCrew;
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+
+/**
+ * Logging a single Leadership-Experience advancement from the Arsenal Sheet.
+ * The controller + LeaderAdvancementService enforce the box-earned / one-per-box
+ * / tier-gating rules; this just shapes the payload.
+ */
+class StoreLeaderAdvancementRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        $crew = $this->route('crew');
+        $campaign = $this->route('campaign');
+
+        return $crew instanceof CampaignCrew
+            && $campaign instanceof Campaign
+            && $crew->campaign_id === $campaign->id
+            && $this->user()
+            && $this->user()->id === $crew->user_id;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function rules(): array
+    {
+        return [
+            'position_in_xp_track' => ['required', 'integer', 'min:0', 'max:38'],
+            'source_table' => ['required', 'string', Rule::enum(AdvancementTableEnum::class)],
+            'catalog_id' => ['nullable', 'integer'],
+            'applied_to_action_index' => ['nullable', 'integer'],
+            'from_equipment_id' => ['nullable', 'integer', 'exists:campaign_equipment,id'],
+            'flip_value' => ['nullable', 'integer', 'min:1', 'max:13'],
+            'free_choice' => ['nullable', 'array'],
+        ];
+    }
+}

--- a/app/Services/Campaign/LeaderAdvancementService.php
+++ b/app/Services/Campaign/LeaderAdvancementService.php
@@ -1,0 +1,139 @@
+<?php
+
+namespace App\Services\Campaign;
+
+use App\Enums\Campaign\AdvancementTableEnum;
+use App\Models\Ability;
+use App\Models\Action;
+use App\Models\Campaign\CampaignLeaderAdvancement;
+use App\Models\CustomCharacter;
+use App\Models\Trigger;
+
+/**
+ * Shared Leadership-Experience advancement engine (pg 31, 38-50). Both the
+ * Aftermath's Advance-Leader step and the Arsenal Sheet's per-box logging use
+ * this so the tier-gating / summoning-once / totem / flip-ceiling rules and the
+ * record shape stay in one place.
+ */
+class LeaderAdvancementService
+{
+    /**
+     * Returns an error string if any advancement breaks a rule, else null.
+     *
+     * @param  array<int, array<string, mixed>>  $advancements
+     */
+    public function validate(CustomCharacter $leader, array $advancements): ?string
+    {
+        // XP-track box tiers keyed by index — the box reached caps tier (pg 31).
+        $track = $leader->xp_track ?? CustomCharacter::defaultXpTrack();
+        $boxTierByIndex = [];
+        foreach ($track as $box) {
+            $boxTierByIndex[$box['index']] = $box['tier'] ?? null;
+        }
+
+        $crewHasTotem = CustomCharacter::query()
+            ->where('campaign_crew_id', $leader->campaign_crew_id)
+            ->where('is_campaign_totem', true)
+            ->where('current', true)
+            ->exists();
+
+        $sawSummoning = false;
+        foreach ($advancements as $a) {
+            $table = AdvancementTableEnum::tryFrom((string) ($a['source_table'] ?? ''));
+            if (! $table) {
+                return 'Unknown advancement table.';
+            }
+
+            // Tier gate against the XP box being filled.
+            $position = $a['position_in_xp_track'] ?? null;
+            $boxTier = $position !== null ? ($boxTierByIndex[$position] ?? null) : null;
+            if ($boxTier === null) {
+                return 'That experience box does not grant an advancement.';
+            }
+            if ($table->tier() > $boxTier) {
+                return "A tier {$table->tier()} advancement cannot be taken at a tier {$boxTier} experience box.";
+            }
+
+            if ($table === AdvancementTableEnum::Summoning) {
+                if ($sawSummoning) {
+                    return 'Summoning Advancement may only be selected once.';
+                }
+                $sawSummoning = true;
+
+                // Campaign-wide check across every prior aftermath on this leader.
+                $existing = CampaignLeaderAdvancement::query()
+                    ->where('custom_character_id', $leader->id)
+                    ->where('source_table', AdvancementTableEnum::Summoning)
+                    ->exists();
+                if ($existing) {
+                    return 'Summoning Advancement has already been used in this campaign.';
+                }
+            }
+
+            if ($table === AdvancementTableEnum::Totem) {
+                if ($crewHasTotem) {
+                    return 'Totem Advancement is only available while the crew has no totem.';
+                }
+
+                $catalogId = $a['catalog_id'] ?? null;
+                $flipValue = $a['flip_value'] ?? null;
+                if ($catalogId === null || $flipValue === null) {
+                    return 'Totem Advancement requires both a totem choice and the flipped value.';
+                }
+                $template = CustomCharacter::query()
+                    ->where('is_campaign_totem_template', true)
+                    ->whereKey($catalogId)
+                    ->first();
+                if (! $template) {
+                    return 'Selected Totem is not a recognized template.';
+                }
+                if ((int) $template->campaign_totem_flip_value !== (int) $flipValue) {
+                    return 'Totem Advancement requires an exact flip-value match — chosen totem does not match the flip.';
+                }
+            }
+
+            // Flip-and-choose ceiling. Each table's catalog row carries its own
+            // campaign_flip_value; the chosen option must be ≤ the flipped card.
+            $catalogId = $a['catalog_id'] ?? null;
+            $flip = $a['flip_value'] ?? null;
+            if ($catalogId !== null && $flip !== null) {
+                $rowFlip = match ($table) {
+                    AdvancementTableEnum::AttackMod, AdvancementTableEnum::TacticalMod => Trigger::query()->whereKey($catalogId)->value('campaign_flip_value'),
+                    AdvancementTableEnum::Action => Action::query()->whereKey($catalogId)->value('campaign_flip_value'),
+                    AdvancementTableEnum::Ability => Ability::query()->whereKey($catalogId)->value('campaign_flip_value'),
+                    default => null,
+                };
+                if ($rowFlip !== null && (int) $rowFlip > (int) $flip) {
+                    return "That advancement needs a flip of {$rowFlip} or higher — your flip was {$flip}.";
+                }
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * Persist the advancement records against the leader.
+     *
+     * @param  array<int, array<string, mixed>>  $advancements
+     */
+    public function create(CustomCharacter $leader, array $advancements, ?int $sourceAftermathId): void
+    {
+        foreach ($advancements as $a) {
+            CampaignLeaderAdvancement::create([
+                'custom_character_id' => $leader->id,
+                'source_aftermath_id' => $sourceAftermathId,
+                'source_table' => $a['source_table'],
+                // Post-consolidation FK to core tables (upgrades / actions /
+                // triggers / abilities / custom_characters depending on
+                // source_table). Legacy catalog_id stays null on new rows.
+                'catalog_core_id' => $a['catalog_id'] ?? null,
+                'from_equipment_id' => $a['from_equipment_id'] ?? null,
+                'applied_to_action_index' => $a['applied_to_action_index'] ?? -1,
+                'position_in_xp_track' => $a['position_in_xp_track'],
+                'free_choice' => $a['free_choice'] ?? null,
+                'acquired_at' => now(),
+            ]);
+        }
+    }
+}

--- a/resources/js/pages/Campaigns/ArsenalSheet.vue
+++ b/resources/js/pages/Campaigns/ArsenalSheet.vue
@@ -4,13 +4,14 @@ import GameText from '@/components/GameText.vue';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Input } from '@/components/ui/input';
 import { useConfirm } from '@/composables/useConfirm';
 import { factionBackground } from '@/composables/useFactionColor';
 import { useToast } from '@/composables/useToast';
 import { type SharedData } from '@/types';
 import { Head, Link, router, usePage } from '@inertiajs/vue3';
 import { Calendar, Copy, Swords, Tag } from 'lucide-vue-next';
-import { computed } from 'vue';
+import { computed, ref } from 'vue';
 
 interface KeywordRow {
     id: number;
@@ -162,12 +163,29 @@ interface XpBox {
     filled: boolean;
     tier: number | null;
 }
+interface AdvancementTaken {
+    id: number;
+    position_in_xp_track: number;
+    source_table: string;
+    catalog_id: number | null;
+    free_choice: Record<string, unknown> | null;
+}
+interface CatalogRow {
+    id: number;
+    name: string;
+    flip_value?: number | null;
+    is_always_available?: boolean;
+}
+type AdvancementCatalogs = Record<string, CatalogRow[]>;
+
 const props = defineProps<{
     campaign: CampaignData;
     crew: CrewData;
     leader: CustomCharacterData | null;
     totem: CustomCharacterData | null;
     leader_xp_track: XpBox[] | null;
+    leader_advancements: AdvancementTaken[];
+    advancement_catalogs: AdvancementCatalogs | null;
     equipment: EquipmentItem[];
     campaign_rating: CampaignRating;
     view_mode: ViewMode;
@@ -175,6 +193,81 @@ const props = defineProps<{
 
 const xpTrack = computed<XpBox[]>(() => props.leader_xp_track ?? []);
 const xpFilled = computed(() => xpTrack.value.filter((b) => b.filled).length);
+
+// ───────── Leadership advancements ─────────
+const advancementCatalogs = computed<AdvancementCatalogs>(() => props.advancement_catalogs ?? {});
+const takenByPosition = computed<Record<number, AdvancementTaken>>(() =>
+    Object.fromEntries(props.leader_advancements.map((a) => [a.position_in_xp_track, a])),
+);
+// Earned advancement slots — filled boxes that grant an advancement (numbered).
+const advancementSlots = computed(() =>
+    xpTrack.value.filter((b) => b.filled && b.tier !== null).map((b) => ({ position: b.index, tier: b.tier as number })),
+);
+
+const FLIP_TABLES = ['attack_mod', 'tactical_mod', 'action', 'ability', 'totem'];
+const tableNeedsFlip = (t: string) => FLIP_TABLES.includes(t);
+const catalogRowsFor = (table: string): CatalogRow[] => advancementCatalogs.value[table] ?? [];
+
+const defaultTableForTier = (tier: number): string => (tier === 1 ? 'attack_mod' : tier === 2 ? 'action' : tier === 3 ? 'totem' : 'crew_card');
+
+const tableOptionsForTier = (tier: number) =>
+    [
+        { value: 'attack_mod', label: 'Tier 1 — Attack Modification', min: 1 },
+        { value: 'tactical_mod', label: 'Tier 1 — Tactical Modification', min: 1 },
+        { value: 'action', label: 'Tier 2 — Action', min: 2 },
+        { value: 'ability', label: 'Tier 2 — Ability', min: 2 },
+        { value: 'totem', label: 'Tier 3 — Totem', min: 3 },
+        { value: 'summoning', label: 'Tier 3 — Summoning', min: 3 },
+        { value: 'crew_card', label: 'Tier 4 — Crew Card effect', min: 4 },
+    ].filter((o) => tier >= o.min);
+
+const eligibleCatalogRows = (table: string, flip: number | null): CatalogRow[] => {
+    const rows = catalogRowsFor(table);
+    if (!tableNeedsFlip(table) || flip == null) return rows;
+    if (table === 'totem') return rows.filter((r) => r.flip_value === flip);
+    return rows.filter((r) => r.is_always_available || r.flip_value == null || (r.flip_value ?? 99) <= flip);
+};
+
+const advancementName = (a: AdvancementTaken): string =>
+    catalogRowsFor(a.source_table).find((r) => r.id === a.catalog_id)?.name ?? a.source_table.replace(/_/g, ' ');
+
+// Per-slot picker drafts — seeded once (the track only changes via a reload).
+interface AdvDraft {
+    source_table: string;
+    catalog_id: number | null;
+    flip_value: number | null;
+}
+const drafts = ref<Record<number, AdvDraft>>({});
+for (const slot of advancementSlots.value) {
+    drafts.value[slot.position] = { source_table: defaultTableForTier(slot.tier), catalog_id: null, flip_value: 13 };
+}
+
+const logAdvancement = (position: number) => {
+    const d = drafts.value[position];
+    if (!d || d.catalog_id == null) {
+        toast.warning('Pick an advancement first.');
+        return;
+    }
+    router.post(route('campaigns.crews.leader.advancements.store', [props.campaign.id, props.crew.share_code]), {
+        position_in_xp_track: position,
+        source_table: d.source_table,
+        catalog_id: d.catalog_id,
+        flip_value: tableNeedsFlip(d.source_table) ? d.flip_value : null,
+    });
+};
+
+const removeAdvancement = async (a: AdvancementTaken) => {
+    if (
+        !(await confirmDialog({
+            title: 'Remove advancement',
+            message: 'Remove this advancement so you can pick a different one?',
+            destructive: true,
+        }))
+    ) {
+        return;
+    }
+    router.delete(route('campaigns.crews.leader.advancements.destroy', [props.campaign.id, props.crew.share_code, a.id]));
+};
 
 const totalArsenalSs = computed(() => props.crew.arsenal_models.reduce((s, m) => s + (m.character?.cost ?? 0), 0));
 
@@ -459,6 +552,68 @@ const totemRendererProps = computed(() => {
                             </div>
                         </div>
                         <p v-else class="text-sm text-muted-foreground">No leader yet.</p>
+
+                        <!-- Advancement slots — one per earned (filled) numbered box. Owners
+                             log what they took; everyone sees the result. -->
+                        <div v-if="advancementSlots.length" class="mt-3 space-y-1.5">
+                            <p class="text-[10px] font-semibold uppercase tracking-wide text-muted-foreground">Advancements</p>
+                            <div v-for="slot in advancementSlots" :key="slot.position" class="rounded-md border p-2 text-xs">
+                                <!-- Logged -->
+                                <div v-if="takenByPosition[slot.position]" class="flex items-center justify-between gap-2">
+                                    <span>
+                                        <Badge variant="outline" class="text-[10px]">Tier {{ slot.tier }}</Badge>
+                                        {{ advancementName(takenByPosition[slot.position]) }}
+                                    </span>
+                                    <Button
+                                        v-if="view_mode.is_owner"
+                                        size="sm"
+                                        variant="ghost"
+                                        @click="removeAdvancement(takenByPosition[slot.position])"
+                                    >
+                                        Remove
+                                    </Button>
+                                </div>
+                                <!-- Owner picker for an empty slot -->
+                                <div v-else-if="view_mode.is_owner && drafts[slot.position]" class="flex flex-wrap items-center gap-1.5">
+                                    <Badge variant="outline" class="text-[10px]">Tier {{ slot.tier }}</Badge>
+                                    <select
+                                        v-model="drafts[slot.position].source_table"
+                                        class="h-8 rounded border bg-background px-2 text-foreground"
+                                        @change="drafts[slot.position].catalog_id = null"
+                                    >
+                                        <option v-for="opt in tableOptionsForTier(slot.tier)" :key="opt.value" :value="opt.value">
+                                            {{ opt.label }}
+                                        </option>
+                                    </select>
+                                    <Input
+                                        v-if="tableNeedsFlip(drafts[slot.position].source_table)"
+                                        v-model.number="drafts[slot.position].flip_value"
+                                        type="number"
+                                        min="1"
+                                        max="13"
+                                        class="h-8 w-14"
+                                    />
+                                    <select
+                                        v-model.number="drafts[slot.position].catalog_id"
+                                        class="h-8 min-w-0 flex-1 rounded border bg-background px-2 text-foreground"
+                                    >
+                                        <option :value="null">— pick —</option>
+                                        <option
+                                            v-for="row in eligibleCatalogRows(drafts[slot.position].source_table, drafts[slot.position].flip_value)"
+                                            :key="row.id"
+                                            :value="row.id"
+                                        >
+                                            {{ row.name }}
+                                        </option>
+                                    </select>
+                                    <Button size="sm" @click="logAdvancement(slot.position)">Log</Button>
+                                </div>
+                                <!-- Viewer, not yet chosen -->
+                                <div v-else class="text-muted-foreground">
+                                    <Badge variant="outline" class="text-[10px]">Tier {{ slot.tier }}</Badge> — not chosen yet
+                                </div>
+                            </div>
+                        </div>
                     </CardContent>
                 </Card>
             </div>

--- a/routes/campaign.php
+++ b/routes/campaign.php
@@ -7,6 +7,7 @@ use App\Http\Controllers\Campaign\CampaignGameController;
 use App\Http\Controllers\Campaign\CampaignInvitationController;
 use App\Http\Controllers\Campaign\CampaignTeaserController;
 use App\Http\Controllers\Campaign\CrewLifecycleController;
+use App\Http\Controllers\Campaign\LeaderAdvancementController;
 use App\Http\Controllers\Campaign\LeaderBuilderController;
 use App\Http\Controllers\Campaign\LeaderSearchController;
 use App\Http\Controllers\Campaign\StartingArsenalController;
@@ -76,6 +77,13 @@ Route::middleware(['campaign.access'])->group(function () {
             ->name('campaigns.crews.leader.search.actions');
         Route::get('/campaigns/{campaign}/crews/{crew}/leader/search/abilities', [LeaderSearchController::class, 'abilities'])
             ->name('campaigns.crews.leader.search.abilities');
+
+        // Leadership Experience — log / remove an advancement straight from the
+        // Arsenal Sheet's XP track (also taken during the Aftermath).
+        Route::post('/campaigns/{campaign}/crews/{crew}/leader/advancements', [LeaderAdvancementController::class, 'store'])
+            ->name('campaigns.crews.leader.advancements.store');
+        Route::delete('/campaigns/{campaign}/crews/{crew}/leader/advancements/{advancement}', [LeaderAdvancementController::class, 'destroy'])
+            ->name('campaigns.crews.leader.advancements.destroy');
 
         // Starting Arsenal — 25-ss spend wizard + crew card effect picker.
         Route::get('/campaigns/{campaign}/crews/{crew}/starting-arsenal', [StartingArsenalController::class, 'edit'])

--- a/tests/Feature/Campaign/LeaderAdvancementTest.php
+++ b/tests/Feature/Campaign/LeaderAdvancementTest.php
@@ -1,0 +1,156 @@
+<?php
+
+use App\Enums\PermissionEnum;
+use App\Models\Campaign\Campaign;
+use App\Models\Campaign\CampaignCrew;
+use App\Models\Campaign\CampaignLeaderAdvancement;
+use App\Models\Campaign\CampaignPlayer;
+use App\Models\CustomCharacter;
+use App\Models\Trigger;
+use App\Models\User;
+use Spatie\Permission\Models\Permission;
+
+beforeEach(function () {
+    foreach (PermissionEnum::cases() as $perm) {
+        Permission::firstOrCreate(['name' => $perm->value]);
+    }
+});
+
+function advUser(): User
+{
+    $user = User::factory()->create(['email_verified_at' => now()]);
+    $user->givePermissionTo(PermissionEnum::UseCampaignMode->value);
+
+    return $user;
+}
+
+/** @return array{Campaign, CampaignCrew, CustomCharacter} */
+function leaderWithEarnedTier1Box(User $user): array
+{
+    $campaign = Campaign::factory()->create(['organizer_user_id' => $user->id]);
+    CampaignPlayer::factory()->organizer()->create(['campaign_id' => $campaign->id, 'user_id' => $user->id]);
+    $crew = CampaignCrew::factory()->create(['campaign_id' => $campaign->id, 'user_id' => $user->id]);
+
+    // Box index 0 is a tier-1 box in the canonical track — mark it earned.
+    $track = CustomCharacter::defaultXpTrack();
+    $track[0]['filled'] = true;
+
+    $leader = CustomCharacter::create([
+        'user_id' => $user->id,
+        'campaign_crew_id' => $crew->id,
+        'is_campaign_leader' => true,
+        'current' => true,
+        'share_code' => 'ldradvtest1',
+        'name' => 'Adv Leader',
+        'display_name' => 'Adv Leader',
+        'slug' => 'adv-leader',
+        'faction' => 'guild',
+        'station' => 'master',
+        'health' => 12, 'defense' => 5, 'willpower' => 6, 'speed' => 5,
+        'tag' => 'bruiser',
+        'xp_track' => $track,
+    ]);
+
+    return [$campaign, $crew, $leader];
+}
+
+it('logs a leader advancement at an earned tier box', function () {
+    $user = advUser();
+    [$campaign, $crew, $leader] = leaderWithEarnedTier1Box($user);
+    $trigger = Trigger::factory()->create(['campaign_flip_value' => 5]);
+
+    $this->actingAs($user)
+        ->post(route('campaigns.crews.leader.advancements.store', [$campaign->id, $crew->share_code]), [
+            'position_in_xp_track' => 0,
+            'source_table' => 'attack_mod',
+            'catalog_id' => $trigger->id,
+            'flip_value' => 13,
+        ])
+        ->assertRedirect();
+
+    expect(CampaignLeaderAdvancement::where('custom_character_id', $leader->id)->where('position_in_xp_track', 0)->count())->toBe(1);
+});
+
+it('rejects an advancement at an unearned box', function () {
+    $user = advUser();
+    [$campaign, $crew, $leader] = leaderWithEarnedTier1Box($user);
+
+    // Box index 2 is a tier-2 box but is NOT filled in our track.
+    $this->actingAs($user)
+        ->post(route('campaigns.crews.leader.advancements.store', [$campaign->id, $crew->share_code]), [
+            'position_in_xp_track' => 2,
+            'source_table' => 'action',
+        ])
+        ->assertRedirect();
+
+    expect(CampaignLeaderAdvancement::where('custom_character_id', $leader->id)->count())->toBe(0);
+});
+
+it('rejects a too-high-tier advancement at a low-tier box', function () {
+    $user = advUser();
+    [$campaign, $crew, $leader] = leaderWithEarnedTier1Box($user); // box 0 = tier 1
+
+    $this->actingAs($user)
+        ->post(route('campaigns.crews.leader.advancements.store', [$campaign->id, $crew->share_code]), [
+            'position_in_xp_track' => 0,
+            'source_table' => 'totem', // tier 3 at a tier-1 box
+        ])
+        ->assertRedirect();
+
+    expect(CampaignLeaderAdvancement::where('custom_character_id', $leader->id)->count())->toBe(0);
+});
+
+it('rejects a second advancement on a box that already has one', function () {
+    $user = advUser();
+    [$campaign, $crew, $leader] = leaderWithEarnedTier1Box($user);
+    CampaignLeaderAdvancement::create([
+        'custom_character_id' => $leader->id,
+        'source_table' => 'attack_mod',
+        'position_in_xp_track' => 0,
+        'applied_to_action_index' => -1,
+        'acquired_at' => now(),
+    ]);
+    $trigger = Trigger::factory()->create(['campaign_flip_value' => 5]);
+
+    $this->actingAs($user)
+        ->post(route('campaigns.crews.leader.advancements.store', [$campaign->id, $crew->share_code]), [
+            'position_in_xp_track' => 0,
+            'source_table' => 'attack_mod',
+            'catalog_id' => $trigger->id,
+            'flip_value' => 13,
+        ])
+        ->assertRedirect();
+
+    expect(CampaignLeaderAdvancement::where('custom_character_id', $leader->id)->count())->toBe(1);
+});
+
+it('removes a logged advancement', function () {
+    $user = advUser();
+    [$campaign, $crew, $leader] = leaderWithEarnedTier1Box($user);
+    $adv = CampaignLeaderAdvancement::create([
+        'custom_character_id' => $leader->id,
+        'source_table' => 'attack_mod',
+        'position_in_xp_track' => 0,
+        'applied_to_action_index' => -1,
+        'acquired_at' => now(),
+    ]);
+
+    $this->actingAs($user)
+        ->delete(route('campaigns.crews.leader.advancements.destroy', [$campaign->id, $crew->share_code, $adv->id]))
+        ->assertRedirect();
+
+    expect(CampaignLeaderAdvancement::find($adv->id))->toBeNull();
+});
+
+it('blocks a non-owner from logging an advancement', function () {
+    $owner = advUser();
+    [$campaign, $crew] = leaderWithEarnedTier1Box($owner);
+    $other = advUser();
+
+    $this->actingAs($other)
+        ->post(route('campaigns.crews.leader.advancements.store', [$campaign->id, $crew->share_code]), [
+            'position_in_xp_track' => 0,
+            'source_table' => 'attack_mod',
+        ])
+        ->assertForbidden();
+});


### PR DESCRIPTION
QA: the XP track lights up but there was nowhere to record what advancement was taken at each tier box. Now each earned (filled) numbered box is an advancement slot on the Arsenal Sheet: the owner picks the table + catalog row (+ flip) and logs it; everyone sees what's taken; the owner can remove one to re-pick.

Extracts the Aftermath's advancement engine into LeaderAdvancementService (tier-gating, summoning-once, totem, flip-ceiling rules + the record shape) so the new sheet endpoint and the Aftermath's Advance-Leader step share one source of truth. Adds the store/destroy endpoints + FormRequest, the sheet payload (taken advancements + catalogs), and the picker UI. Tests for the endpoint; existing aftermath/arsenal suites stay green.