### PR TITLE
fix: Campaign QA batch + server-generated Leader/Totem card images

### DIFF
--- a/_ide_helper_models.php
+++ b/_ide_helper_models.php
@@ -1512,6 +1512,9 @@ namespace App\Models{
  * @property array<array-key, mixed>|null $characteristics
  * @property array<array-key, mixed>|null $linked_crew_upgrades
  * @property array<array-key, mixed>|null $linked_totems
+ * @property string|null $front_image
+ * @property string|null $back_image
+ * @property string|null $combination_image
  * @property string|null $notes
  * @property \Illuminate\Support\Carbon|null $created_at
  * @property \Illuminate\Support\Carbon|null $updated_at
@@ -1532,6 +1535,7 @@ namespace App\Models{
  * @method static \Illuminate\Database\Eloquent\Builder<static>|CustomCharacter whereActions($value)
  * @method static \Illuminate\Database\Eloquent\Builder<static>|CustomCharacter whereAnnihilatedAt($value)
  * @method static \Illuminate\Database\Eloquent\Builder<static>|CustomCharacter whereArchetype($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|CustomCharacter whereBackImage($value)
  * @method static \Illuminate\Database\Eloquent\Builder<static>|CustomCharacter whereBase($value)
  * @method static \Illuminate\Database\Eloquent\Builder<static>|CustomCharacter whereCampaignCrewId($value)
  * @method static \Illuminate\Database\Eloquent\Builder<static>|CustomCharacter whereCampaignDf($value)
@@ -1545,6 +1549,7 @@ namespace App\Models{
  * @method static \Illuminate\Database\Eloquent\Builder<static>|CustomCharacter whereCampaignTotemSpecialReplace($value)
  * @method static \Illuminate\Database\Eloquent\Builder<static>|CustomCharacter whereCampaignWp($value)
  * @method static \Illuminate\Database\Eloquent\Builder<static>|CustomCharacter whereCharacteristics($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|CustomCharacter whereCombinationImage($value)
  * @method static \Illuminate\Database\Eloquent\Builder<static>|CustomCharacter whereCost($value)
  * @method static \Illuminate\Database\Eloquent\Builder<static>|CustomCharacter whereCount($value)
  * @method static \Illuminate\Database\Eloquent\Builder<static>|CustomCharacter whereCreatedAt($value)
@@ -1554,6 +1559,7 @@ namespace App\Models{
  * @method static \Illuminate\Database\Eloquent\Builder<static>|CustomCharacter whereDeletedAt($value)
  * @method static \Illuminate\Database\Eloquent\Builder<static>|CustomCharacter whereDisplayName($value)
  * @method static \Illuminate\Database\Eloquent\Builder<static>|CustomCharacter whereFaction($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|CustomCharacter whereFrontImage($value)
  * @method static \Illuminate\Database\Eloquent\Builder<static>|CustomCharacter whereGeneratesStone($value)
  * @method static \Illuminate\Database\Eloquent\Builder<static>|CustomCharacter whereHealth($value)
  * @method static \Illuminate\Database\Eloquent\Builder<static>|CustomCharacter whereId($value)

--- a/app/Http/Controllers/Campaign/ArsenalSheetController.php
+++ b/app/Http/Controllers/Campaign/ArsenalSheetController.php
@@ -79,7 +79,7 @@ class ArsenalSheetController extends Controller
                 'character:id,slug,display_name,cost,faction,station',
                 // First standard miniature provides the card image for CharacterCardView.
                 'character.standardMiniatures:id,display_name,front_image,back_image,character_id,slug',
-                'injuries.injury:id,name',
+                'injuries.injury:id,name,description',
             ]),
         ]);
 
@@ -108,17 +108,17 @@ class ArsenalSheetController extends Controller
         if (! empty($leaderTotemIds)) {
             $injuriesByCharacter = CampaignArsenalModelInjury::query()
                 ->whereIn('custom_character_id', $leaderTotemIds)
-                ->with('injury:id,name')
+                ->with('injury:id,name,description')
                 ->get()
                 ->groupBy('custom_character_id');
 
             $leader?->setAttribute(
                 'injury_names',
-                ($injuriesByCharacter->get($leader->id) ?? collect())->map(fn ($i) => $i->injury?->name)->filter()->values(),
+                ($injuriesByCharacter->get($leader->id) ?? collect())->map(fn ($i) => $this->shapeInjury($i))->filter()->values()->all(),
             );
             $totem?->setAttribute(
                 'injury_names',
-                ($injuriesByCharacter->get($totem->id) ?? collect())->map(fn ($i) => $i->injury?->name)->filter()->values(),
+                ($injuriesByCharacter->get($totem->id) ?? collect())->map(fn ($i) => $this->shapeInjury($i))->filter()->values()->all(),
             );
         }
 
@@ -164,7 +164,7 @@ class ArsenalSheetController extends Controller
                             ...$m->character->only(['id', 'slug', 'display_name', 'cost', 'faction', 'station']),
                             'standard_miniature' => $m->character->standardMiniatures->first()?->only(['id', 'display_name', 'front_image', 'back_image', 'character_id', 'slug']),
                         ] : null,
-                        'injuries' => $m->injuries->map(fn ($i) => $i->injury?->name)->filter()->values(),
+                        'injuries' => $m->injuries->map(fn ($i) => $this->shapeInjury($i))->filter()->values()->all(),
                         'gained_characteristics' => $m->gained_characteristics ?? [],
                         'lucky_miss' => collect($m->gained_lucky_miss_ids ?? [])
                             ->map(fn ($id) => $luckyMissNames[$id] ?? null)
@@ -233,5 +233,22 @@ class ArsenalSheetController extends Controller
                 'share_url' => route('campaigns.crews.arsenal.share', $crew->share_code),
             ],
         ]);
+    }
+
+    /**
+     * Shapes an injury pivot's loaded `injury` relation for display — the
+     * description is what lets the Arsenal Sheet's injury badges open a
+     * "what does this do" viewer instead of just showing the bare name.
+     *
+     * @return array{id: int, name: string, description: string|null}|null
+     */
+    private function shapeInjury(CampaignArsenalModelInjury $pivot): ?array
+    {
+        $injury = $pivot->injury;
+        if (! $injury) {
+            return null;
+        }
+
+        return ['id' => $injury->id, 'name' => $injury->name, 'description' => $injury->description];
     }
 }

--- a/app/Http/Controllers/CustomCharacterController.php
+++ b/app/Http/Controllers/CustomCharacterController.php
@@ -121,6 +121,46 @@ class CustomCharacterController extends Controller
         ]);
     }
 
+    /**
+     * Bare front/back card faces, no page chrome — the headless-Chrome
+     * capture target for App\Services\Campaign\LeaderCardImageGenerator.
+     * Props are shaped here (camelCase, enums resolved to their value)
+     * instead of client-side, matching what CardFrontFace/CardBackFace
+     * expect directly, so the capture page needs no adapter logic.
+     */
+    public function capture(string $shareCode): Response
+    {
+        $character = CustomCharacter::where('share_code', $shareCode)->firstOrFail();
+
+        return inertia('CardCreator/Capture', [
+            'card' => [
+                'name' => $character->name,
+                'title' => $character->title,
+                'faction' => $character->faction?->value,
+                'secondFaction' => $character->second_faction?->value,
+                'station' => $character->station?->value,
+                'cost' => $character->cost,
+                'health' => $character->health,
+                'defense' => $character->defense,
+                'defenseSuit' => $character->defense_suit?->value,
+                'willpower' => $character->willpower,
+                'willpowerSuit' => $character->willpower_suit?->value,
+                'speed' => $character->speed,
+                'size' => $character->size,
+                'base' => (string) ($character->base->value ?? ''),
+                'keywords' => $character->keywords ?? [],
+                'characteristics' => $character->characteristics ?? [],
+                // Never populated — Custom Card Creator character art is
+                // client-blob-only, not persisted server-side.
+                'characterImage' => null,
+                'actions' => $character->actions ?? [],
+                'abilities' => $character->abilities ?? [],
+                'linkedCrewUpgrades' => $character->linked_crew_upgrades ?? [],
+                'linkedTotems' => $character->linked_totems ?? [],
+            ],
+        ]);
+    }
+
     private function validateCharacter(Request $request): array
     {
         return $request->validate([

--- a/app/Http/Controllers/Game/GameController.php
+++ b/app/Http/Controllers/Game/GameController.php
@@ -208,7 +208,7 @@ class GameController extends Controller
         // crew + turn snapshots.
         if ($context === GameShowContext::Summary) {
             return array_merge($loads, [
-                'players.crewMembers.customCharacter:id,faction,actions,abilities',
+                'players.crewMembers.customCharacter:id,faction,actions,abilities,display_name,front_image,back_image',
                 'players.crewBuild',
                 'players.master.crewUpgrades',
                 'players.turns',
@@ -219,7 +219,7 @@ class GameController extends Controller
         if ($context === GameShowContext::SelfView) {
             // Participants also need crews during Scheme Select.
             if (in_array($game->status, [GameStatusEnum::SchemeSelect, ...$postSetup])) {
-                $loads[] = 'players.crewMembers.customCharacter:id,faction,actions,abilities';
+                $loads[] = 'players.crewMembers.customCharacter:id,faction,actions,abilities,display_name,front_image,back_image';
                 $loads[] = 'players.crewBuild';
                 $loads[] = 'players.master.crewUpgrades';
             }
@@ -230,7 +230,7 @@ class GameController extends Controller
             }
         } elseif (in_array($game->status, $postSetup)) {
             // Observer: crews + full turns once gameplay has started.
-            $loads[] = 'players.crewMembers.customCharacter:id,faction,actions,abilities';
+            $loads[] = 'players.crewMembers.customCharacter:id,faction,actions,abilities,display_name,front_image,back_image';
             $loads[] = 'players.crewBuild';
             $loads[] = 'players.master.crewUpgrades';
             $loads[] = 'players.turns';
@@ -494,6 +494,7 @@ class GameController extends Controller
             $props['campaign_leader_option'] = fn () => $game->format === \App\Enums\GameFormatEnum::Campaign
                 ? $this->campaignLeaderMasterOption($game)
                 : null;
+            $props['campaign_totem'] = fn () => $this->buildCampaignTotemProp($game);
         }
 
         return $props;
@@ -630,6 +631,28 @@ class GameController extends Controller
             })
             ->values()
             ->all();
+    }
+
+    /**
+     * The crew's current Totem (if unlocked, Tier-3+), offered as an
+     * equipment-assignment target alongside the Leader and hires at
+     * CrewSelect. Null on any non-Campaign game, wrong status, or a crew
+     * that hasn't unlocked a Totem yet.
+     *
+     * @return array{id: int, name: string}|null
+     */
+    private function buildCampaignTotemProp(Game $game): ?array
+    {
+        if ($game->format !== \App\Enums\GameFormatEnum::Campaign
+            || $game->status !== \App\Enums\GameStatusEnum::CrewSelect
+            || ! Auth::check()) {
+            return null;
+        }
+
+        $campaignCrew = $this->resolveCampaignCrewForUser($game);
+        $totem = $campaignCrew?->totem;
+
+        return $totem ? ['id' => $totem->id, 'name' => $totem->name] : null;
     }
 
     /**

--- a/app/Http/Controllers/Game/GameSetupController.php
+++ b/app/Http/Controllers/Game/GameSetupController.php
@@ -729,7 +729,10 @@ class GameSetupController extends Controller
                     'front_image' => null,
                     'back_image' => null,
                     'is_custom' => true,
-                    'attached_upgrades' => $this->injuryUpgrades('custom_character_id', $campaignTotem->id),
+                    'attached_upgrades' => array_merge(
+                        $this->injuryUpgrades('custom_character_id', $campaignTotem->id),
+                        $equipmentByTarget['totem'] ?? [],
+                    ),
                     'attached_tokens' => [],
                     'attached_markers' => [],
                     'sort_order' => $sortOrder++,
@@ -905,15 +908,19 @@ class GameSetupController extends Controller
 
         foreach ($assignments as $a) {
             $equipmentId = (int) $a['equipment_id'];
-            $target = $a['target'] === 'leader' ? 'leader' : (int) $a['target'];
+            $target = in_array($a['target'], ['leader', 'totem'], true) ? $a['target'] : (int) $a['target'];
 
             $entry = $owned->get($equipmentId);
             if (! $entry) {
                 return "One or more assigned equipment pieces aren't in your crew's owned equipment.";
             }
 
-            if ($target !== 'leader' && ! in_array($target, $characterIds, true)) {
-                return 'Equipment can only be assigned to the Leader or a model you\'re hiring this game.';
+            if ($target === 'totem') {
+                if (! $crew->totem) {
+                    return "Equipment can't be assigned to a Totem — this crew hasn't unlocked one yet.";
+                }
+            } elseif ($target !== 'leader' && ! in_array($target, $characterIds, true)) {
+                return 'Equipment can only be assigned to the Leader, Totem, or a model you\'re hiring this game.';
             }
 
             $usedCounts[$equipmentId] = ($usedCounts[$equipmentId] ?? 0) + 1;

--- a/app/Jobs/Campaign/GenerateLeaderCardImage.php
+++ b/app/Jobs/Campaign/GenerateLeaderCardImage.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace App\Jobs\Campaign;
+
+use App\Models\CustomCharacter;
+use App\Services\Campaign\LeaderCardImageGenerator;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldBeUnique;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+
+/**
+ * Regenerates a Campaign Leader/Totem's card images in the background.
+ * ShouldBeUnique collapses a burst of saves (e.g. picking several Tier-4
+ * advancements in one Aftermath submit) into a single render.
+ */
+class GenerateLeaderCardImage implements ShouldBeUnique, ShouldQueue
+{
+    use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
+
+    public int $timeout = 120;
+
+    public function __construct(public int $customCharacterId) {}
+
+    public function uniqueId(): string
+    {
+        return "leader-card-{$this->customCharacterId}";
+    }
+
+    public function handle(LeaderCardImageGenerator $generator): void
+    {
+        $character = CustomCharacter::find($this->customCharacterId);
+        if (! $character) {
+            return;
+        }
+
+        try {
+            $generator->generate($character);
+        } catch (\Throwable $e) {
+            // Best-effort: a render failure must not bubble up and block
+            // whatever request (Aftermath advance, Leader Builder save, ...)
+            // triggered this dispatch.
+            report($e);
+        }
+    }
+}

--- a/app/Observers/CustomCharacterObserver.php
+++ b/app/Observers/CustomCharacterObserver.php
@@ -2,11 +2,25 @@
 
 namespace App\Observers;
 
+use App\Jobs\Campaign\GenerateLeaderCardImage;
 use App\Models\CustomCharacter;
 use Illuminate\Support\Str;
 
 class CustomCharacterObserver
 {
+    /**
+     * Columns that actually affect the rendered card — CardFrontFace/
+     * CardBackFace's full prop list (see LeaderCardImageGenerator).
+     *
+     * @var array<int, string>
+     */
+    private const CARD_RENDER_COLUMNS = [
+        'name', 'title', 'faction', 'second_faction', 'station', 'cost',
+        'health', 'defense', 'defense_suit', 'willpower', 'willpower_suit',
+        'speed', 'size', 'base', 'keywords', 'characteristics', 'actions',
+        'abilities', 'linked_crew_upgrades', 'linked_totems',
+    ];
+
     public function creating(CustomCharacter $character): void
     {
         $character->display_name = $character->name;
@@ -41,5 +55,39 @@ class CustomCharacterObserver
             }
             $character->slug = $slug;
         }
+    }
+
+    /**
+     * Card-image regeneration (Campaign Leaders/Totems only, pg 31/52) — the
+     * single hook every mutation path funnels through (Leader Builder,
+     * Advance Leader, direct Arsenal Sheet advancement logging/removal, Totem
+     * creation), so none of those call sites need to remember to trigger it
+     * themselves. Generic homebrew Custom Card Creator characters are
+     * unaffected — they stay client-side-render-only.
+     *
+     * Dedicated `created`/`updated` hooks rather than the combined `saved`
+     * event: Eloquent only populates change-tracking (`wasChanged()`) on
+     * updates, not inserts, and `wasRecentlyCreated` stays true for the rest
+     * of that model instance's lifetime once set — neither reliably tells
+     * "was this specific save a create or an update" on its own.
+     */
+    public function created(CustomCharacter $character): void
+    {
+        if ($character->is_campaign_leader || $character->is_campaign_totem) {
+            GenerateLeaderCardImage::dispatch($character->id);
+        }
+    }
+
+    public function updated(CustomCharacter $character): void
+    {
+        if (! $character->is_campaign_leader && ! $character->is_campaign_totem) {
+            return;
+        }
+
+        if (! $character->wasChanged(self::CARD_RENDER_COLUMNS)) {
+            return;
+        }
+
+        GenerateLeaderCardImage::dispatch($character->id);
     }
 }

--- a/app/Services/Campaign/LeaderAdvancementService.php
+++ b/app/Services/Campaign/LeaderAdvancementService.php
@@ -164,11 +164,12 @@ class LeaderAdvancementService
                 }
             }
 
-            // Ability target resolution (pg 44-51): applies to the Leader
-            // (default) or the crew's current Totem — same routing as
-            // Attack/Tactical Mod, minus the per-action Skl range check
-            // (an Ability isn't attached to a specific existing action).
-            if ($table === AdvancementTableEnum::Ability) {
+            // Ability/Summoning target resolution (pg 44-51): applies to the
+            // Leader (default) or the crew's current Totem — same routing as
+            // Attack/Tactical Mod, minus the per-action Skl range check (an
+            // Ability/Summoning action isn't attached to a specific existing
+            // action).
+            if ($table === AdvancementTableEnum::Ability || $table === AdvancementTableEnum::Summoning) {
                 $appliedToCustomCharacterId = $a['applied_to_custom_character_id'] ?? null;
                 if ($appliedToCustomCharacterId !== null) {
                     $totemExists = CustomCharacter::query()
@@ -409,8 +410,8 @@ class LeaderAdvancementService
                     isset($a['totem_size']) ? (int) $a['totem_size'] : null,
                     $a['totem_base'] ?? null,
                 ),
-                AdvancementTableEnum::Summoning => $coreCatalogId
-                    ? $this->applyActionToLeader($leader, $coreCatalogId)
+                AdvancementTableEnum::Summoning => ($targetCharacter && $coreCatalogId)
+                    ? $this->applyActionToLeader($targetCharacter, $coreCatalogId)
                     : null,
                 AdvancementTableEnum::Action => $advancementRow instanceof AdvancementAction
                     ? $this->applyAdvancementAction($leader, $advancementRow, $freeChoice)
@@ -836,7 +837,7 @@ class LeaderAdvancementService
 
         $abilities = $template->campaignTotemAbilities->map(fn (Ability $ab) => [
             'name' => $ab->name,
-            'body' => $ab->description,
+            'description' => $ab->description,
             'suits' => $ab->suits,
             'source_id' => $ab->id,
         ])->all();
@@ -995,7 +996,7 @@ class LeaderAdvancementService
             return;
         }
 
-        if ($table === AdvancementTableEnum::Action || $table === AdvancementTableEnum::Summoning) {
+        if ($table === AdvancementTableEnum::Action) {
             if ($catalogId === null) {
                 return;
             }
@@ -1013,6 +1014,34 @@ class LeaderAdvancementService
                 }
             ));
             $leader->save();
+
+            return;
+        }
+
+        if ($table === AdvancementTableEnum::Summoning) {
+            if ($catalogId === null) {
+                return;
+            }
+            $target = $advancement->applied_to_custom_character_id !== null
+                ? CustomCharacter::find($advancement->applied_to_custom_character_id)
+                : $leader;
+            if (! $target) {
+                return;
+            }
+            $removed = false;
+            $target->actions = array_values(array_filter(
+                $target->actions ?? [],
+                function (array $a) use ($catalogId, &$removed): bool {
+                    if (! $removed && ($a['source_id'] ?? null) === $catalogId) {
+                        $removed = true;
+
+                        return false;
+                    }
+
+                    return true;
+                }
+            ));
+            $target->save();
 
             return;
         }

--- a/app/Services/Campaign/LeaderCardImageGenerator.php
+++ b/app/Services/Campaign/LeaderCardImageGenerator.php
@@ -1,0 +1,86 @@
+<?php
+
+namespace App\Services\Campaign;
+
+use App\Models\CustomCharacter;
+use Illuminate\Support\Facades\Storage;
+use Spatie\Browsershot\Browsershot;
+
+/**
+ * Renders a Campaign Leader/Totem's card to real PNGs via headless Chrome
+ * (Browsershot) and saves them the same way Miniature/Upgrade store their
+ * front/back/combination art (App\Console\Commands\CreateCombinationImages).
+ *
+ * Unlike App\Services\BonanzaDeckPdfGenerator (which renders a hand-written
+ * Blade template), this navigates Browsershot to a live, minimal Inertia page
+ * (CustomCharacterController::capture) that mounts the *real*
+ * CardFrontFace/CardBackFace Vue components — the generated image is
+ * pixel-identical to the live card preview because it is that component, with
+ * no CSS duplicated/kept in sync by hand.
+ */
+class LeaderCardImageGenerator
+{
+    /**
+     * Capture front + back, merge them into a combination image, and save all
+     * three onto the character. Directory mirrors Miniature's
+     * `characters/{character_id}/...` convention.
+     */
+    public function generate(CustomCharacter $character): void
+    {
+        $dir = "custom-characters/{$character->id}";
+        $url = route('tools.card_creator.capture', $character->share_code);
+
+        $front = $this->capture($url, '#card-front');
+        Storage::disk('public')->put("{$dir}/front.png", $front);
+
+        $back = $this->capture($url, '#card-back');
+        Storage::disk('public')->put("{$dir}/back.png", $back);
+
+        $this->mergeSideBySide(
+            Storage::disk('public')->path("{$dir}/front.png"),
+            Storage::disk('public')->path("{$dir}/back.png"),
+            Storage::disk('public')->path("{$dir}/combination.png"),
+        );
+
+        $character->update([
+            'front_image' => "{$dir}/front.png",
+            'back_image' => "{$dir}/back.png",
+            'combination_image' => "{$dir}/combination.png",
+        ]);
+    }
+
+    private function capture(string $url, string $selector): string
+    {
+        $browsershot = Browsershot::url($url)
+            ->noSandbox()
+            ->select($selector)
+            ->deviceScaleFactor(2)
+            ->waitUntilNetworkIdle()
+            ->timeout(60);
+
+        if ($node = config('services.browsershot.node_binary')) {
+            $browsershot->setNodeBinary($node);
+        }
+        if ($npm = config('services.browsershot.npm_binary')) {
+            $browsershot->setNpmBinary($npm);
+        }
+        if ($chrome = config('services.browsershot.chrome_path')) {
+            $browsershot->setChromePath($chrome);
+        }
+
+        return $browsershot->screenshot();
+    }
+
+    /** Side-by-side merge — same GD approach as CreateCombinationImages, PNG instead of JPEG. */
+    private function mergeSideBySide(string $frontPath, string $backPath, string $outPath): void
+    {
+        [$fw, $fh] = getimagesize($frontPath);
+        [$bw, $bh] = getimagesize($backPath);
+
+        $canvas = imagecreatetruecolor($fw + $bw, max($fh, $bh));
+        imagecopy($canvas, imagecreatefrompng($frontPath), 0, 0, 0, 0, $fw, $fh);
+        imagecopy($canvas, imagecreatefrompng($backPath), $fw, 0, 0, 0, $bw, $bh);
+        imagepng($canvas, $outPath);
+        imagedestroy($canvas);
+    }
+}

--- a/app/Support/Campaign/AftermathCatalog.php
+++ b/app/Support/Campaign/AftermathCatalog.php
@@ -464,19 +464,29 @@ class AftermathCatalog
      * `attached_upgrades` — shared by Game Tracker's in-play "attach
      * upgrade" editor and by equipment assignment at crew selection.
      *
-     * @return array<int, array{id: int, name: string, slug: string, front_image: string|null, back_image: string|null, type: mixed, plentiful: int, power_bar_count: int|null, description: string|null}>
+     * @return array<int, array{id: int, name: string, slug: string, front_image: string|null, back_image: string|null, type: mixed, plentiful: int, power_bar_count: int|null, description: string|null, actions: array<int, array<string, mixed>>, abilities: array<int, array<string, mixed>>}>
      */
     public static function ownedEquipmentForAttachment(CampaignCrew $crew): array
     {
         return CampaignEquipment::query()
             ->where('campaign_crew_id', $crew->id)
             ->active()
-            ->with('catalog:id,name,slug,front_image,back_image,type,power_bar_count,description')
+            ->with([
+                'catalog:id,name,slug,front_image,back_image,type,power_bar_count,description',
+                // Full action/ability text so the in-play "attach upgrade"
+                // drawer can render ActionCard/AbilityCard instead of just
+                // the bare description — same pattern as crewCardEffect.
+                'catalog.actions' => fn ($q) => $q->with('triggers:id,name,suits,stone_cost,description'),
+                'catalog.abilities',
+            ])
             ->get()
             ->filter(fn (CampaignEquipment $e) => $e->catalog !== null)
             ->groupBy('equipment_upgrade_id')
             ->map(function (Collection $owned) {
                 $u = $owned->first()->catalog;
+                $u->actions->each(
+                    fn (Action $a) => $a->is_signature = (bool) $a->pivot->is_signature_action, // @phpstan-ignore property.notFound (pivot from morphedByMany)
+                );
 
                 return [
                     'id' => $u->id,
@@ -488,6 +498,30 @@ class AftermathCatalog
                     'plentiful' => $owned->count(),
                     'power_bar_count' => $u->power_bar_count,
                     'description' => $u->description,
+                    'actions' => $u->actions->map(fn (Action $a) => [
+                        'name' => $a->name,
+                        'type' => $a->type,
+                        'is_signature' => $a->is_signature,
+                        'stone_cost' => $a->stone_cost,
+                        'range' => $a->range,
+                        'range_type' => $a->range_type,
+                        'stat' => $a->stat,
+                        'stat_suits' => $a->stat_suits,
+                        'stat_modifier' => $a->stat_modifier,
+                        'resisted_by' => $a->resisted_by,
+                        'target_number' => $a->target_number,
+                        'target_suits' => $a->target_suits,
+                        'damage' => $a->damage,
+                        'description' => $a->description,
+                        'triggers' => self::triggerSummaries($a->triggers),
+                    ])->all(),
+                    'abilities' => $u->abilities->map(fn (Ability $ab) => [
+                        'name' => $ab->name,
+                        'suits' => $ab->suits,
+                        'defensive_ability_type' => $ab->defensive_ability_type,
+                        'costs_stone' => $ab->costs_stone,
+                        'description' => $ab->description,
+                    ])->all(),
                 ];
             })
             ->sortBy('name')
@@ -605,6 +639,7 @@ class AftermathCatalog
             'advancements' => $advancementRows->map(fn (CampaignLeaderAdvancement $row) => [
                 'table' => $row->source_table->label(),
                 'name' => self::advancementDisplayName($row),
+                'target' => self::advancementTargetName($row),
             ])->all(),
             'doctor_attempts' => $doctorRows->map(fn ($row) => [
                 'target' => $row->target_arsenal_model_id
@@ -633,6 +668,25 @@ class AftermathCatalog
         };
 
         return $name ?? $row->source_table->label();
+    }
+
+    /**
+     * Who an advancement actually landed on — the Leader by default, the
+     * routed Totem (pg 31, 38-43), or the piece of Equipment it modifies.
+     * `custom_character_id` is always the row's owning Leader; a set
+     * `applied_to_custom_character_id` overrides that with a Totem reroute.
+     */
+    private static function advancementTargetName(CampaignLeaderAdvancement $row): string
+    {
+        if ($row->from_equipment_id !== null) {
+            $equipment = CampaignEquipment::query()->with('catalog:id,name')->find($row->from_equipment_id);
+
+            return $equipment?->catalog->name ?? 'Equipment';
+        }
+
+        $targetId = $row->applied_to_custom_character_id ?? $row->custom_character_id;
+
+        return CustomCharacter::find($targetId)->name ?? 'Leader';
     }
 
     private static function advancementActionName(?int $advancementActionId): ?string

--- a/database/migrations/2026_07_10_203354_add_leader_card_images_to_custom_characters_table.php
+++ b/database/migrations/2026_07_10_203354_add_leader_card_images_to_custom_characters_table.php
@@ -1,0 +1,37 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        // Server-rendered card images (front/back/combination — same shape as
+        // Miniature/Upgrade's), populated only for Campaign Leaders/Totems
+        // (is_campaign_leader/is_campaign_totem) via a headless-Chrome capture
+        // triggered whenever the character's card-relevant data changes — see
+        // App\Services\Campaign\LeaderCardImageGenerator. Generic homebrew
+        // Custom Card Creator characters stay client-side-render-only (no
+        // server image baking), unaffected by this column addition.
+        Schema::table('custom_characters', function (Blueprint $table) {
+            $table->string('front_image')->nullable()->after('linked_totems');
+            $table->string('back_image')->nullable()->after('front_image');
+            $table->string('combination_image')->nullable()->after('back_image');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('custom_characters', function (Blueprint $table) {
+            $table->dropColumn(['front_image', 'back_image', 'combination_image']);
+        });
+    }
+};

--- a/resources/js/components/Game/GameAttachedUpgradeDrawer.vue
+++ b/resources/js/components/Game/GameAttachedUpgradeDrawer.vue
@@ -1,15 +1,48 @@
 <script setup lang="ts">
+import AbilityCard from '@/components/AbilityCard.vue';
+import ActionCard from '@/components/ActionCard.vue';
 import BonanzaCardImage from '@/components/Bonanza/BonanzaCardImage.vue';
 import UpgradeFlipCard from '@/components/UpgradeFlipCard.vue';
 import { Button } from '@/components/ui/button';
 import { Drawer, DrawerClose, DrawerContent, DrawerFooter, DrawerHeader, DrawerTitle } from '@/components/ui/drawer';
 import { X } from 'lucide-vue-next';
 
+interface UpgradeAction {
+    name: string;
+    type?: string;
+    is_signature?: boolean;
+    stone_cost?: number;
+    range?: number | string | null;
+    range_type?: string;
+    stat?: number | string | null;
+    stat_suits?: string | null;
+    stat_modifier?: string | null;
+    resisted_by?: string | null;
+    target_number?: number | string | null;
+    target_suits?: string | null;
+    damage?: string | null;
+    description?: string | null;
+    triggers?: Array<{ id?: number; name: string; suits?: string; stone_cost?: number; description?: string }>;
+}
+
+interface UpgradeAbility {
+    name: string;
+    suits?: string | null;
+    defensive_ability_type?: string | null;
+    costs_stone?: boolean;
+    description?: string | null;
+}
+
 interface UpgradePreview {
     name: string;
     front_image: string;
     back_image: string | null;
     description?: string | null;
+    // Full granted actions/abilities (Campaign equipment, pg 19) — rendered
+    // as proper ActionCard/AbilityCard so a player can see the real rules
+    // text, not just the flavor description.
+    actions?: UpgradeAction[];
+    abilities?: UpgradeAbility[];
     loot_card_id?: number;
     loot_side?: 'a' | 'b';
 }
@@ -68,12 +101,23 @@ const emit = defineEmits<{
                         />
                     </div>
                     <!-- No card art uploaded — show the effect text instead of a blank preview. -->
-                    <p v-else class="px-4 pb-2 text-sm leading-relaxed text-muted-foreground">
-                        {{ upgrade.description || 'No description available.' }}
+                    <p
+                        v-else-if="!upgrade.description && !upgrade.actions?.length && !upgrade.abilities?.length"
+                        class="px-4 pb-2 text-sm leading-relaxed text-muted-foreground"
+                    >
+                        No description available.
+                    </p>
+                    <p v-else-if="upgrade.description" class="px-4 pb-2 text-sm leading-relaxed text-muted-foreground">
+                        {{ upgrade.description }}
                     </p>
                     <p v-if="upgrade.front_image && upgrade.description" class="px-4 pb-2 text-sm leading-relaxed text-muted-foreground">
                         {{ upgrade.description }}
                     </p>
+                    <!-- Granted actions/abilities (Campaign equipment, pg 19) — full rules text, not just flavor. -->
+                    <div v-if="upgrade.actions?.length || upgrade.abilities?.length" class="max-h-[40dvh] space-y-2 overflow-y-auto px-4 pb-2">
+                        <ActionCard v-for="(a, i) in upgrade.actions ?? []" :key="`eq-action-${i}`" :action="a" :hide-footer="true" />
+                        <AbilityCard v-for="(ab, i) in upgrade.abilities ?? []" :key="`eq-ability-${i}`" :ability="ab" :hide-footer="true" />
+                    </div>
                 </template>
                 <DrawerFooter class="shrink-0 pt-2">
                     <DrawerClose as-child>

--- a/resources/js/components/Game/GameCrewSelectPanel.vue
+++ b/resources/js/components/Game/GameCrewSelectPanel.vue
@@ -77,6 +77,7 @@ const props = defineProps<{
     isCampaign: boolean;
     campaignArsenal: CampaignArsenalModel[];
     campaignOwnedEquipment: CampaignOwnedEquipment[];
+    campaignTotem: { id: number; name: string } | null;
     submitting: boolean;
     mySlot: number;
     opponentSlot: number;
@@ -203,6 +204,7 @@ const equipmentSlots = computed<EquipmentSlot[]>(() =>
 );
 const equipmentTargetOptions = computed(() => [
     { value: 'leader', label: 'Leader' },
+    ...(props.campaignTotem ? [{ value: 'totem', label: props.campaignTotem.name }] : []),
     ...selectedArsenalIds.value.map((id) => ({
         value: String(id),
         label: props.campaignArsenal.find((a) => a.character_id === id)?.name ?? `#${id}`,
@@ -210,7 +212,7 @@ const equipmentTargetOptions = computed(() => [
 ]);
 // Drop any assignment whose target was deselected from the crew.
 watch(selectedArsenalIds, () => {
-    const validTargets = new Set(['__none__', 'leader', ...selectedArsenalIds.value.map(String)]);
+    const validTargets = new Set(['__none__', 'leader', 'totem', ...selectedArsenalIds.value.map(String)]);
     for (const key of Object.keys(equipmentTargets.value)) {
         if (!validTargets.has(equipmentTargets.value[key])) equipmentTargets.value[key] = '__none__';
     }

--- a/resources/js/pages/Campaigns/Aftermath.vue
+++ b/resources/js/pages/Campaigns/Aftermath.vue
@@ -310,7 +310,7 @@ interface PhaseSummary {
     scrip_earned: number;
     barter: Array<{ name: string; cc: number }>;
     barter_total_cc: number;
-    advancements: Array<{ table: string; name: string }>;
+    advancements: Array<{ table: string; name: string; target: string }>;
     doctor_attempts: Array<{ target: string; outcome: string }>;
 }
 interface AdvancementCatalogs {
@@ -534,6 +534,18 @@ const onCrewCardMasterRowChange = (position: number, v: string) => {
     onCatalogChange(position);
 };
 
+// A generic (master_id === null) row picked straight from the flat list still
+// requires naming the master it's borrowed from (pg 32, 54 — every Tier-4
+// effect is tied to a real master's card, even if the catalog hasn't been
+// backfilled with that master yet). Unlike onCrewCardMasterChange, this
+// doesn't touch catalog_id — the picked row itself doesn't change, only its
+// attribution.
+const onCrewCardGenericMasterChange = (position: number, v: string) => {
+    const d = advDrafts.value[position];
+    if (!d) return;
+    d.free_choice_source_character_id = v === '__none__' ? null : Number(v);
+};
+
 // ───────── Any Joker free-choice search (Action/Ability tables, pg 49/51) ─────────
 const jokerSearch = ref<Record<number, string>>({});
 const jokerResults = ref<Record<number, Array<{ id: number; name: string; source_id: number; source_character_id: number | null }>>>({});
@@ -695,6 +707,7 @@ const submitAdvanceLeader = () => {
                 const isTotemAdvancement = d.source_table === 'totem';
                 const isTrigger = d.source_table === 'attack_mod' || d.source_table === 'tactical_mod';
                 const isAbility = d.source_table === 'ability';
+                const isSummoning = d.source_table === 'summoning';
                 const isEquipmentTarget = isTrigger && d.target_type === 'equipment';
                 return {
                     source_table: d.source_table,
@@ -702,7 +715,7 @@ const submitAdvanceLeader = () => {
                     applied_to_action_index: isTrigger && !isEquipmentTarget ? d.applied_to_action_index : undefined,
                     applied_to_action_id: isEquipmentTarget ? d.applied_to_action_id : undefined,
                     applied_to_custom_character_id:
-                        (isTrigger || isAbility) && d.target_type === 'totem' ? (xp_track.value?.totem_id ?? undefined) : undefined,
+                        (isTrigger || isAbility || isSummoning) && d.target_type === 'totem' ? (xp_track.value?.totem_id ?? undefined) : undefined,
                     from_equipment_id: isEquipmentTarget ? (d.target_equipment_id ?? undefined) : undefined,
                     joker_color: isTrigger ? d.joker_color : undefined,
                     position_in_xp_track: adv.position_in_xp_track,
@@ -1132,7 +1145,12 @@ const finalize = () =>
                 <!-- Advancements queued for numbered boxes -->
                 <fieldset v-if="advancementsQueued.length" class="rounded-md border p-3 text-sm">
                     <legend class="px-1 text-xs font-medium uppercase text-muted-foreground">Advancements ({{ advancementsQueued.length }})</legend>
-                    <div v-for="(adv, idx) in advancementsQueued" :key="idx" class="space-y-2 border-b py-2 last:border-b-0">
+                    <div
+                        v-for="(adv, idx) in advancementsQueued"
+                        :key="idx"
+                        class="space-y-2 border-b px-2 py-2 last:border-b-0"
+                        :class="idx % 2 === 1 ? 'bg-muted/40' : ''"
+                    >
                         <p class="text-xs">Box {{ adv.position_in_xp_track + 1 }} — Tier {{ adv.box_tier }} advancement</p>
                         <template v-if="advDrafts[adv.position_in_xp_track]">
                             <Select
@@ -1225,7 +1243,7 @@ const finalize = () =>
                                         :key="row.id"
                                         :value="row.id.toString()"
                                     >
-                                        {{ row.name }}<span v-if="row.flip_value != null"> (flip {{ row.flip_value }})</span>
+                                        {{ row.name }}
                                     </SelectItem>
                                 </SelectContent>
                             </Select>
@@ -1301,6 +1319,30 @@ const finalize = () =>
                                             No Crew Card catalog rows are linked to this master yet.
                                         </p>
                                     </div>
+                                </div>
+                                <!-- A generic row was picked directly — still needs a "borrowed from" master (pg 32, 54). -->
+                                <div
+                                    v-if="
+                                        !advDrafts[adv.position_in_xp_track].crew_card_master_mode &&
+                                        advDrafts[adv.position_in_xp_track].catalog_id !== null
+                                    "
+                                    class="rounded border p-2"
+                                >
+                                    <Label class="text-[11px] text-muted-foreground">Borrowed from master</Label>
+                                    <Select
+                                        :model-value="advDrafts[adv.position_in_xp_track].free_choice_source_character_id?.toString() ?? '__none__'"
+                                        @update:model-value="(v) => onCrewCardGenericMasterChange(adv.position_in_xp_track, v as string)"
+                                    >
+                                        <SelectTrigger class="h-8 w-full text-xs text-foreground">
+                                            <SelectValue placeholder="— pick a master —" />
+                                        </SelectTrigger>
+                                        <SelectContent>
+                                            <SelectItem value="__none__">— pick a master —</SelectItem>
+                                            <SelectItem v-for="m in eligible_masters ?? []" :key="m.id" :value="m.id.toString()">{{
+                                                m.name
+                                            }}</SelectItem>
+                                        </SelectContent>
+                                    </Select>
                                 </div>
                             </div>
                             <!-- Any Joker: search for the free action/ability pick (non-master/totem ally, cost <= 10, pg 49/51) -->
@@ -1513,10 +1555,11 @@ const finalize = () =>
                                     </Select>
                                 </div>
                             </div>
-                            <!-- Ability: pick what to affect (Leader/Totem) -->
+                            <!-- Ability/Summoning: pick what to affect (Leader/Totem) -->
                             <div
                                 v-if="
-                                    advDrafts[adv.position_in_xp_track].source_table === 'ability' &&
+                                    (advDrafts[adv.position_in_xp_track].source_table === 'ability' ||
+                                        advDrafts[adv.position_in_xp_track].source_table === 'summoning') &&
                                     advDrafts[adv.position_in_xp_track].catalog_id !== null
                                 "
                                 class="flex flex-wrap items-center gap-2"
@@ -1795,13 +1838,15 @@ const finalize = () =>
                         >
                         <span v-else class="font-medium">nothing bought</span>
                     </p>
-                    <p>
-                        Advancements:
-                        <span v-if="phase_summary.advancements.length" class="font-medium">{{
-                            phase_summary.advancements.map((a) => `${a.table}: ${a.name}`).join(', ')
-                        }}</span>
-                        <span v-else class="font-medium">none taken</span>
-                    </p>
+                    <div>
+                        <span>Advancements:</span>
+                        <span v-if="!phase_summary.advancements.length" class="font-medium">none taken</span>
+                        <ul v-else class="mt-1 list-disc space-y-0.5 pl-5">
+                            <li v-for="(a, i) in phase_summary.advancements" :key="i">
+                                <span class="font-medium">{{ a.table }}: {{ a.name }}</span> — {{ a.target }}
+                            </li>
+                        </ul>
+                    </div>
                     <p>
                         Doctor:
                         <span v-if="phase_summary.doctor_attempts.length" class="font-medium">{{
@@ -1813,7 +1858,7 @@ const finalize = () =>
 
                 <div class="space-y-2 rounded-md border p-3 text-sm">
                     <p class="text-xs font-medium uppercase text-muted-foreground">Phase 6 — Determine Injuries (not yet saved)</p>
-                    <p v-if="!injuryFlips.length" class="font-medium">No injuries recorded.</p>
+                    <p v-if="!injuryFlips.length" class="font-medium">No new injuries.</p>
                     <ul v-else class="space-y-1">
                         <li v-for="(f, idx) in injuryFlips" :key="idx">
                             <span class="font-medium">{{ modelDisplayName(f) }}</span> — {{ injuryFlipSummary(f) }}

--- a/resources/js/pages/Campaigns/ArsenalSheet.vue
+++ b/resources/js/pages/Campaigns/ArsenalSheet.vue
@@ -2,6 +2,7 @@
 import AbilityCard from '@/components/AbilityCard.vue';
 import ActionCard from '@/components/ActionCard.vue';
 import CardRenderer from '@/components/CardCreator/CardRenderer.vue';
+import { blobToDataURL, createComboImage, fetchFontEmbedCSS, triggerDownload } from '@/components/CardCreator/utils';
 import CharacterCardView from '@/components/CharacterCardView.vue';
 import EmptyState from '@/components/EmptyState.vue';
 import GameText from '@/components/GameText.vue';
@@ -21,7 +22,7 @@ import { useToast } from '@/composables/useToast';
 import { CARD_HOVER } from '@/lib/cardHover';
 import { type SharedData } from '@/types';
 import { Head, Link, router, usePage } from '@inertiajs/vue3';
-import { Calendar, Copy, Swords, Tag } from 'lucide-vue-next';
+import { Calendar, Copy, Download, Swords, Tag } from 'lucide-vue-next';
 import { computed, ref, watch } from 'vue';
 
 interface KeywordRow {
@@ -105,6 +106,7 @@ interface AbilityData {
 interface CustomCharacterData {
     id: number;
     name: string;
+    display_name: string;
     title: string | null;
     faction: string;
     second_faction: string | null;
@@ -121,11 +123,23 @@ interface CustomCharacterData {
     keywords: Array<{ id: number | null; name: string }>;
     characteristics: string[];
     image_path: string | null;
+    // Server-rendered card images (App\Services\Campaign\LeaderCardImageGenerator),
+    // regenerated automatically whenever the card-relevant fields above change.
+    // Null until the first render lands — callers fall back to the live CardRenderer.
+    front_image: string | null;
+    back_image: string | null;
+    combination_image: string | null;
     actions: ActionData[];
     abilities: AbilityData[];
     linked_crew_upgrades: Array<{ source_type: 'official' | 'custom'; id: number; name: string }>;
     linked_totems: Array<{ source_type: 'official' | 'custom'; id: number; name: string }>;
-    injury_names?: string[];
+    injury_names?: InjuryItem[];
+}
+
+interface InjuryItem {
+    id: number;
+    name: string;
+    description: string | null;
 }
 
 interface ArsenalCharacter {
@@ -152,7 +166,7 @@ interface ArsenalRow {
     ignored_for_limits: boolean;
     acquired_via: string;
     character: ArsenalCharacter | null;
-    injuries: string[];
+    injuries: InjuryItem[];
     gained_characteristics: string[];
     lucky_miss: string[];
 }
@@ -426,6 +440,16 @@ const onCrewCardMasterRowChange = (position: number, v: string) => {
     d.crew_card_choice_id = null;
 };
 
+// A generic (master_id === null) row picked straight from the flat list still
+// requires naming the master it's borrowed from (pg 32, 54). Unlike
+// onCrewCardMasterChange, this doesn't touch catalog_id — the picked row
+// itself doesn't change, only its attribution.
+const onCrewCardGenericMasterChange = (position: number, v: string) => {
+    const d = drafts.value[position];
+    if (!d) return;
+    d.free_choice_source_character_id = v === '__none__' ? null : Number(v);
+};
+
 const SOURCE_TABLE_LABELS: Record<string, string> = {
     attack_mod: 'Attack Modification',
     tactical_mod: 'Tactical Modification',
@@ -603,6 +627,7 @@ const logAdvancement = (position: number) => {
     const isTotemAdvancement = d.source_table === 'totem';
     const isTrigger = d.source_table === 'attack_mod' || d.source_table === 'tactical_mod';
     const isAbility = d.source_table === 'ability';
+    const isSummoning = d.source_table === 'summoning';
     const isEquipmentTarget = isTrigger && d.target_type === 'equipment';
     if (isTrigger && targetActionOptions(position).length) {
         if (isEquipmentTarget ? d.applied_to_action_id == null : d.applied_to_action_index < 0) {
@@ -624,7 +649,8 @@ const logAdvancement = (position: number) => {
         totem_base: isTotemAdvancement ? d.totem_base : undefined,
         applied_to_action_index: isTrigger && !isEquipmentTarget ? d.applied_to_action_index : undefined,
         applied_to_action_id: isEquipmentTarget ? d.applied_to_action_id : undefined,
-        applied_to_custom_character_id: (isTrigger || isAbility) && d.target_type === 'totem' ? (props.totem?.id ?? undefined) : undefined,
+        applied_to_custom_character_id:
+            (isTrigger || isAbility || isSummoning) && d.target_type === 'totem' ? (props.totem?.id ?? undefined) : undefined,
         from_equipment_id: isEquipmentTarget ? (d.target_equipment_id ?? undefined) : undefined,
         crew_card_choice: d.crew_card_choice_id !== null ? { id: d.crew_card_choice_id } : null,
     });
@@ -645,11 +671,17 @@ const removeAdvancement = async (a: AdvancementTaken) => {
 
 const totalArsenalSs = computed(() => props.crew.arsenal_models.reduce((s, m) => s + (m.character?.cost ?? 0), 0));
 
-// ───────── Card viewer (equipment / crew card — Dialog) ─────────
-type CardView = { kind: 'equipment'; title: string; equipment: EquipmentItem } | { kind: 'crew'; title: string; effect: CrewCardEffectRow };
+// ───────── Card viewer (equipment / crew card / injury — Dialog) ─────────
+type CardView =
+    | { kind: 'equipment'; title: string; equipment: EquipmentItem }
+    | { kind: 'crew'; title: string; effect: CrewCardEffectRow }
+    | { kind: 'injury'; title: string; description: string | null };
 const viewCard = ref<CardView | null>(null);
 const viewEquipment = (equipment: EquipmentItem) => {
     viewCard.value = { kind: 'equipment', title: equipment.name, equipment };
+};
+const viewInjury = (injury: InjuryItem) => {
+    viewCard.value = { kind: 'injury', title: injury.name, description: injury.description };
 };
 // Merges the starter effect with every currently-held Tier-4 borrowed effect
 // (pg 32, 54) into one combined card view, so newly-added borrowed effects
@@ -783,6 +815,65 @@ const totemRendererProps = computed(() => {
         linkedTotems: props.totem.linked_totems ?? [],
     };
 });
+
+// Card image export (pg 31, 52) — same front+back PNG capture the Custom
+// Card Creator's editor uses (html-to-image + the shared CardCreator/utils
+// helpers), reused here so a Leader/Totem's card can be saved/shared like any
+// other Malifaux card. Leader/Totem never have uploaded art (characterImage
+// is always null), so there are no blob: image sources to convert — the
+// blobToDataURL step is a no-op but kept for parity with the editor.
+const leaderCardRendererRef = ref<InstanceType<typeof CardRenderer> | null>(null);
+const totemCardRendererRef = ref<InstanceType<typeof CardRenderer> | null>(null);
+const exportingCard = ref<'leader' | 'totem' | null>(null);
+
+const exportCardImage = async (which: 'leader' | 'totem') => {
+    const rendererRef = which === 'leader' ? leaderCardRendererRef.value : totemCardRendererRef.value;
+    const cardName = which === 'leader' ? props.leader?.name : props.totem?.name;
+    if (!rendererRef || !cardName) return;
+
+    exportingCard.value = which;
+    try {
+        const frontEl = rendererRef.frontRef;
+        const backEl = rendererRef.backRef;
+        if (!frontEl || !backEl) return;
+
+        const { toPng } = await import('html-to-image');
+        const fontEmbedCSS = await fetchFontEmbedCSS();
+        const opts = { pixelRatio: 2, skipFonts: true, fontEmbedCSS };
+
+        const blobImages = frontEl.querySelectorAll<HTMLImageElement>('img[src^="blob:"]');
+        const origSrcs: { el: HTMLImageElement; src: string }[] = [];
+        for (const img of blobImages) {
+            origSrcs.push({ el: img, src: img.src });
+            img.src = await blobToDataURL(img.src);
+        }
+
+        const origFrontBackface = frontEl.style.backfaceVisibility;
+        frontEl.style.backfaceVisibility = 'visible';
+        const frontData = await toPng(frontEl, opts);
+        frontEl.style.backfaceVisibility = origFrontBackface;
+
+        for (const { el, src } of origSrcs) {
+            el.src = src;
+        }
+
+        const origTransform = backEl.style.transform;
+        const origBackface = backEl.style.backfaceVisibility;
+        backEl.style.transform = 'none';
+        backEl.style.backfaceVisibility = 'visible';
+        const backData = await toPng(backEl, opts);
+        backEl.style.transform = origTransform;
+        backEl.style.backfaceVisibility = origBackface;
+
+        const comboData = await createComboImage(frontData, backData);
+        triggerDownload(comboData, `${cardName}.png`);
+    } catch (e) {
+        console.error('Card image export failed:', e);
+        toast.error('Could not export the card image — try again.');
+    } finally {
+        exportingCard.value = null;
+    }
+};
 </script>
 
 <template>
@@ -873,13 +964,70 @@ const totemRendererProps = computed(() => {
             <!-- Leader card -->
             <div class="lg:col-span-2">
                 <Card>
-                    <CardHeader><CardTitle>Leader</CardTitle></CardHeader>
+                    <CardHeader class="flex-row items-center justify-between space-y-0">
+                        <CardTitle>Leader</CardTitle>
+                        <a
+                            v-if="leader?.combination_image"
+                            :href="'/storage/' + leader.combination_image"
+                            download
+                            class="inline-flex h-8 items-center gap-1.5 rounded-md border px-3 text-xs font-medium text-foreground transition-colors hover:bg-accent"
+                        >
+                            <Download class="size-3.5" />
+                            Download Card
+                        </a>
+                        <Button
+                            v-else-if="leaderRendererProps"
+                            size="sm"
+                            variant="outline"
+                            :disabled="exportingCard === 'leader'"
+                            @click="exportCardImage('leader')"
+                        >
+                            <Download class="size-3.5" />
+                            {{ exportingCard === 'leader' ? 'Exporting…' : 'Download Card' }}
+                        </Button>
+                    </CardHeader>
                     <CardContent>
-                        <div v-if="leaderRendererProps" class="mx-auto w-full max-w-[500px] space-y-2">
-                            <CardRenderer v-bind="leaderRendererProps" />
+                        <div v-if="leader?.front_image" class="mx-auto w-full max-w-[280px] space-y-2">
+                            <CharacterCardView
+                                :miniature="{
+                                    id: leader.id,
+                                    display_name: leader.display_name,
+                                    slug: '',
+                                    front_image: leader.front_image,
+                                    back_image: leader.back_image,
+                                }"
+                                :show-link="false"
+                                :show-collection="false"
+                            />
                             <div v-if="leader?.injury_names?.length" class="flex flex-wrap gap-1">
-                                <Badge v-for="inj in leader.injury_names" :key="`leader-i-${inj}`" variant="destructive" class="text-[10px]">
-                                    {{ inj }}
+                                <Badge
+                                    v-for="inj in leader.injury_names"
+                                    :key="`leader-i-${inj.id}`"
+                                    variant="destructive"
+                                    class="cursor-pointer text-[10px]"
+                                    role="button"
+                                    tabindex="0"
+                                    @click="viewInjury(inj)"
+                                    @keydown.enter="viewInjury(inj)"
+                                >
+                                    {{ inj.name }}
+                                </Badge>
+                            </div>
+                        </div>
+                        <div v-else-if="leaderRendererProps" class="mx-auto w-full max-w-[500px] space-y-2">
+                            <CardRenderer ref="leaderCardRendererRef" v-bind="leaderRendererProps" />
+                            <div v-if="leader?.injury_names?.length" class="flex flex-wrap gap-1">
+                                <Badge
+                                    v-for="inj in leader.injury_names"
+                                    :key="`leader-i-${inj.id}`"
+                                    variant="destructive"
+                                    class="cursor-pointer text-[10px]"
+                                    role="button"
+                                    tabindex="0"
+                                    @click="viewInjury(inj)"
+                                    @keydown.enter="viewInjury(inj)"
+                                >
+                                    {{ inj.name }}
                                 </Badge>
                             </div>
                         </div>
@@ -894,13 +1042,64 @@ const totemRendererProps = computed(() => {
                 </Card>
 
                 <Card v-if="totemRendererProps" class="mt-4">
-                    <CardHeader><CardTitle>Totem</CardTitle></CardHeader>
+                    <CardHeader class="flex-row items-center justify-between space-y-0">
+                        <CardTitle>Totem</CardTitle>
+                        <a
+                            v-if="totem?.combination_image"
+                            :href="'/storage/' + totem.combination_image"
+                            download
+                            class="inline-flex h-8 items-center gap-1.5 rounded-md border px-3 text-xs font-medium text-foreground transition-colors hover:bg-accent"
+                        >
+                            <Download class="size-3.5" />
+                            Download Card
+                        </a>
+                        <Button v-else size="sm" variant="outline" :disabled="exportingCard === 'totem'" @click="exportCardImage('totem')">
+                            <Download class="size-3.5" />
+                            {{ exportingCard === 'totem' ? 'Exporting…' : 'Download Card' }}
+                        </Button>
+                    </CardHeader>
                     <CardContent>
-                        <div class="mx-auto w-full max-w-[500px] space-y-2">
-                            <CardRenderer v-bind="totemRendererProps" />
+                        <div v-if="totem?.front_image" class="mx-auto w-full max-w-[280px] space-y-2">
+                            <CharacterCardView
+                                :miniature="{
+                                    id: totem.id,
+                                    display_name: totem.display_name,
+                                    slug: '',
+                                    front_image: totem.front_image,
+                                    back_image: totem.back_image,
+                                }"
+                                :show-link="false"
+                                :show-collection="false"
+                            />
                             <div v-if="totem?.injury_names?.length" class="flex flex-wrap gap-1">
-                                <Badge v-for="inj in totem.injury_names" :key="`totem-i-${inj}`" variant="destructive" class="text-[10px]">
-                                    {{ inj }}
+                                <Badge
+                                    v-for="inj in totem.injury_names"
+                                    :key="`totem-i-${inj.id}`"
+                                    variant="destructive"
+                                    class="cursor-pointer text-[10px]"
+                                    role="button"
+                                    tabindex="0"
+                                    @click="viewInjury(inj)"
+                                    @keydown.enter="viewInjury(inj)"
+                                >
+                                    {{ inj.name }}
+                                </Badge>
+                            </div>
+                        </div>
+                        <div v-else class="mx-auto w-full max-w-[500px] space-y-2">
+                            <CardRenderer ref="totemCardRendererRef" v-bind="totemRendererProps" />
+                            <div v-if="totem?.injury_names?.length" class="flex flex-wrap gap-1">
+                                <Badge
+                                    v-for="inj in totem.injury_names"
+                                    :key="`totem-i-${inj.id}`"
+                                    variant="destructive"
+                                    class="cursor-pointer text-[10px]"
+                                    role="button"
+                                    tabindex="0"
+                                    @click="viewInjury(inj)"
+                                    @keydown.enter="viewInjury(inj)"
+                                >
+                                    {{ inj.name }}
                                 </Badge>
                             </div>
                         </div>
@@ -1115,7 +1314,7 @@ const totemRendererProps = computed(() => {
                                                     :key="row.id"
                                                     :value="row.id.toString()"
                                                 >
-                                                    {{ row.name }}<span v-if="row.flip_value != null"> (flip {{ row.flip_value }})</span>
+                                                    {{ row.name }}
                                                 </SelectItem>
                                             </SelectContent>
                                         </Select>
@@ -1189,6 +1388,31 @@ const totemRendererProps = computed(() => {
                                                 No Crew Card catalog rows are linked to this master yet.
                                             </p>
                                         </div>
+                                    </div>
+                                    <!-- A generic row was picked directly — still needs a "borrowed from" master (pg 32, 54). -->
+                                    <div
+                                        v-if="
+                                            drafts[slot.position].source_table === 'crew_card' &&
+                                            !drafts[slot.position].crew_card_master_mode &&
+                                            drafts[slot.position].catalog_id !== null
+                                        "
+                                        class="rounded border p-2"
+                                    >
+                                        <Label class="text-[11px] text-muted-foreground">Borrowed from master</Label>
+                                        <Select
+                                            :model-value="drafts[slot.position].free_choice_source_character_id?.toString() ?? '__none__'"
+                                            @update:model-value="(v) => onCrewCardGenericMasterChange(slot.position, v as string)"
+                                        >
+                                            <SelectTrigger class="h-8 w-full text-xs text-foreground">
+                                                <SelectValue placeholder="— pick a master —" />
+                                            </SelectTrigger>
+                                            <SelectContent>
+                                                <SelectItem value="__none__">— pick a master —</SelectItem>
+                                                <SelectItem v-for="m in eligible_masters ?? []" :key="m.id" :value="m.id.toString()">{{
+                                                    m.name
+                                                }}</SelectItem>
+                                            </SelectContent>
+                                        </Select>
                                     </div>
                                     <!-- Any Joker: search for the free action/ability pick (non-master/totem ally, cost <= 10, pg 49/51) -->
                                     <div
@@ -1388,9 +1612,13 @@ const totemRendererProps = computed(() => {
                                             </Select>
                                         </template>
                                     </div>
-                                    <!-- Ability: pick what to affect (Leader/Totem) -->
+                                    <!-- Ability/Summoning: pick what to affect (Leader/Totem) -->
                                     <div
-                                        v-if="drafts[slot.position].source_table === 'ability' && drafts[slot.position].catalog_id !== null"
+                                        v-if="
+                                            (drafts[slot.position].source_table === 'ability' ||
+                                                drafts[slot.position].source_table === 'summoning') &&
+                                            drafts[slot.position].catalog_id !== null
+                                        "
                                         class="flex flex-wrap items-center gap-2"
                                     >
                                         <Label class="shrink-0 text-[11px] text-muted-foreground">Affects:</Label>
@@ -1487,7 +1715,18 @@ const totemRendererProps = computed(() => {
                         >
                             <Badge v-if="model.acquired_via === 'doppelganger'" variant="secondary" class="text-[10px]">Doppelganger</Badge>
                             <Badge v-if="model.acquired_via === 'traitor'" variant="secondary" class="text-[10px]">Defected</Badge>
-                            <Badge v-for="inj in model.injuries" :key="`i-${inj}`" variant="destructive" class="text-[10px]">{{ inj }}</Badge>
+                            <Badge
+                                v-for="inj in model.injuries"
+                                :key="`i-${inj.id}`"
+                                variant="destructive"
+                                class="cursor-pointer text-[10px]"
+                                role="button"
+                                tabindex="0"
+                                @click.stop="viewInjury(inj)"
+                                @keydown.enter.stop="viewInjury(inj)"
+                            >
+                                {{ inj.name }}
+                            </Badge>
                             <Badge v-for="ch in model.gained_characteristics" :key="`c-${ch}`" variant="outline" class="text-[10px]">{{ ch }}</Badge>
                             <Badge v-for="lm in model.lucky_miss" :key="`l-${lm}`" class="bg-green-600 text-[10px] text-white hover:bg-green-600">
                                 {{ lm }}
@@ -1629,6 +1868,14 @@ const totemRendererProps = computed(() => {
                         <ActionCard v-for="ac in viewCard.effect.actions" :key="`cac-${ac.id}`" :action="ac" :hide-footer="true" />
                     </div>
                 </div>
+
+                <!-- Injury -->
+                <div v-else-if="viewCard?.kind === 'injury'" class="text-sm">
+                    <p v-if="viewCard.description" class="text-xs leading-relaxed text-muted-foreground">
+                        <GameText :text="viewCard.description" />
+                    </p>
+                    <p v-else class="text-xs text-muted-foreground">No rules text recorded for this injury.</p>
+                </div>
             </DialogContent>
         </Dialog>
     </div>
@@ -1650,7 +1897,18 @@ const totemRendererProps = computed(() => {
                         v-if="unitPreviewRow.injuries.length || unitPreviewRow.gained_characteristics.length"
                         class="mt-1.5 flex flex-wrap justify-center gap-1"
                     >
-                        <Badge v-for="inj in unitPreviewRow.injuries" :key="`di-${inj}`" variant="destructive" class="text-[10px]">{{ inj }}</Badge>
+                        <Badge
+                            v-for="inj in unitPreviewRow.injuries"
+                            :key="`di-${inj.id}`"
+                            variant="destructive"
+                            class="cursor-pointer text-[10px]"
+                            role="button"
+                            tabindex="0"
+                            @click="viewInjury(inj)"
+                            @keydown.enter="viewInjury(inj)"
+                        >
+                            {{ inj.name }}
+                        </Badge>
                         <Badge v-for="ch in unitPreviewRow.gained_characteristics" :key="`dc-${ch}`" variant="outline" class="text-[10px]">{{
                             ch
                         }}</Badge>

--- a/resources/js/pages/CardCreator/Capture.vue
+++ b/resources/js/pages/CardCreator/Capture.vue
@@ -1,0 +1,123 @@
+<script setup lang="ts">
+import CardBackFace from '@/components/CardCreator/CardBackFace.vue';
+import CardFrontFace from '@/components/CardCreator/CardFrontFace.vue';
+import { Head } from '@inertiajs/vue3';
+
+interface KeywordData {
+    id: number | null;
+    name: string;
+}
+
+interface TriggerData {
+    name: string;
+    suits: string | null;
+    stone_cost: number;
+    description: string | null;
+    source_id: number | null;
+}
+
+interface ActionData {
+    name: string;
+    type: string;
+    is_signature: boolean;
+    stone_cost: number;
+    range: number | null;
+    range_type: string | null;
+    stat: number | null;
+    stat_suits: string | null;
+    stat_modifier: string | null;
+    resisted_by: string | null;
+    target_number: number | null;
+    target_suits: string | null;
+    damage: string | null;
+    description: string | null;
+    source_id: number | null;
+    triggers: TriggerData[];
+}
+
+interface AbilityData {
+    name: string;
+    suits: string | null;
+    defensive_ability_type: string | null;
+    costs_stone: boolean;
+    description: string | null;
+    source_id: number | null;
+}
+
+interface LinkedItem {
+    source_type: 'official' | 'custom';
+    id: number;
+    name: string;
+}
+
+defineProps<{
+    card: {
+        name: string;
+        title: string | null;
+        faction: string | null;
+        secondFaction: string | null;
+        station: string;
+        cost: number | null;
+        health: number;
+        defense: number;
+        defenseSuit: string | null;
+        willpower: number;
+        willpowerSuit: string | null;
+        speed: number;
+        size: number | null;
+        base: string;
+        keywords: KeywordData[];
+        characteristics: string[];
+        characterImage: string | null;
+        actions: ActionData[];
+        abilities: AbilityData[];
+        linkedCrewUpgrades: LinkedItem[];
+        linkedTotems: LinkedItem[];
+    };
+}>();
+</script>
+
+<template>
+    <Head title="Card capture" />
+
+    <!-- Headless-Chrome capture target only — App\Services\Campaign\LeaderCardImageGenerator
+         screenshots #card-front and #card-back individually via Browsershot's ->select().
+         Fixed pixel size (not the flexible aspect-ratio the interactive CardRenderer uses)
+         so the capture has a deterministic bounding box regardless of viewport. -->
+    <div class="flex gap-8 bg-transparent p-8">
+        <div id="card-front" style="width: 550px; height: 950px">
+            <CardFrontFace
+                :name="card.name"
+                :title="card.title"
+                :faction="card.faction"
+                :second-faction="card.secondFaction"
+                :station="card.station"
+                :cost="card.cost"
+                :health="card.health"
+                :defense="card.defense"
+                :defense-suit="card.defenseSuit"
+                :willpower="card.willpower"
+                :willpower-suit="card.willpowerSuit"
+                :speed="card.speed"
+                :size="card.size"
+                :base="card.base"
+                :keywords="card.keywords"
+                :characteristics="card.characteristics"
+                :character-image="card.characterImage"
+                :abilities="card.abilities"
+                :linked-crew-upgrades="card.linkedCrewUpgrades"
+                :linked-totems="card.linkedTotems"
+            />
+        </div>
+        <div id="card-back" style="width: 550px; height: 950px">
+            <CardBackFace
+                :name="card.name"
+                :title="card.title"
+                :faction="card.faction"
+                :second-faction="card.secondFaction"
+                :actions="card.actions"
+                :abilities="card.abilities"
+            />
+        </div>
+    </div>
+</template>

--- a/resources/js/pages/Games/Show.vue
+++ b/resources/js/pages/Games/Show.vue
@@ -216,6 +216,11 @@ const props = defineProps<{
         type: string | null;
         plentiful: number | null;
         power_bar_count: number | null;
+        description?: string | null;
+        // Campaign equipment only (pg 19) — full granted actions/abilities so
+        // the attach-upgrade drawer can render real rules text.
+        actions?: Array<Record<string, unknown>>;
+        abilities?: Array<Record<string, unknown>>;
     }[];
     all_markers: { id: number; name: string; slug: string }[];
     all_reachable_schemes: SchemeData[];
@@ -286,6 +291,9 @@ const props = defineProps<{
     }[];
     /** Campaign games only: the current user's built leader for their own master pick. */
     campaign_leader_option?: MasterOption | null;
+    /** Campaign games only: the crew's current Totem (Tier-3+ unlock), offered
+     *  as an equipment-assignment target during crew select. Null if not yet unlocked. */
+    campaign_totem?: { id: number; name: string } | null;
 }>();
 
 const page = usePage<SharedData>();
@@ -437,10 +445,16 @@ const postSetup = async (endpoint: string, body: Record<string, unknown>) => {
                 'bonanza_crew_upgrades',
                 'campaign_arsenal',
                 'campaign_owned_equipment',
+                'campaign_totem',
                 // campaign_leader_option depends on the player's faction, which is
                 // only set once submitFaction completes — must reload here or the
                 // leader stays blank at Master Select until a manual refresh.
                 'campaign_leader_option',
+                // campaign_context carries crew_a_card/crew_b_card (starter +
+                // borrowed Crew Card effects) — must reload here too, or the
+                // in-game "[crew card]" toggle stays stale/empty until a manual
+                // refresh once crew selection actually sets up the crews.
+                'campaign_context',
             ],
             preserveScroll: true,
             preserveState: true,
@@ -1115,10 +1129,13 @@ const openCardFullscreen = (payload: { src: string; backSrc?: string | null; tit
 const upgradeDrawerOpen = ref(false);
 const previewUpgrade = ref<any>(null);
 
-// Campaign Leader/Totem (pg 31, 52) have no card art at all — their stat
-// block is JSON on the linked CustomCharacter instead of front_image.
+// Campaign Leader/Totem (pg 31, 52) — a server-rendered card image
+// (custom_character.front_image) once one's been generated, else the raw
+// actions/abilities JSON as a fallback stat block.
 const hasCustomCharacterCard = (member: any): boolean =>
-    (member.custom_character?.actions?.length ?? 0) > 0 || (member.custom_character?.abilities?.length ?? 0) > 0;
+    !!member.custom_character?.front_image ||
+    (member.custom_character?.actions?.length ?? 0) > 0 ||
+    (member.custom_character?.abilities?.length ?? 0) > 0;
 
 const openMemberPreview = (member: any) => {
     if (!member.front_image && !member.back_image && !hasCustomCharacterCard(member)) return;
@@ -1323,7 +1340,7 @@ const closeLootPicker = () => {
 };
 
 const openUpgradePreview = (upgrade: any) => {
-    if (!upgrade.front_image && !upgrade.description) return;
+    if (!upgrade.front_image && !upgrade.description && !upgrade.actions?.length && !upgrade.abilities?.length) return;
     previewUpgrade.value = upgrade;
     upgradeDrawerOpen.value = true;
 };
@@ -2446,7 +2463,15 @@ const toggleUpgrade = async (upgrade: {
     // catalog (character_upgrades) so callers don't have to thread it through.
     const catalog = props.character_upgrades.find((u) => u.id === upgrade.id);
     const powerMax = catalog?.power_bar_count ?? upgrade.power_bar_count ?? null;
-    const newRow: any = { id: upgrade.id, name: upgrade.name, front_image: upgrade.front_image, back_image: upgrade.back_image };
+    const newRow: any = {
+        id: upgrade.id,
+        name: upgrade.name,
+        front_image: upgrade.front_image,
+        back_image: upgrade.back_image,
+        description: catalog?.description ?? null,
+        actions: catalog?.actions ?? [],
+        abilities: catalog?.abilities ?? [],
+    };
     if (powerMax !== null && powerMax > 0) {
         newRow.current_power_bar = 0;
     }
@@ -2502,7 +2527,7 @@ const previewAttachedUpgrade = ref<any>(null);
 const attachedUpgradeDrawerOpen = ref(false);
 
 const openAttachedUpgradePreview = (upgrade: any) => {
-    if (!upgrade.front_image && !upgrade.description) return;
+    if (!upgrade.front_image && !upgrade.description && !upgrade.actions?.length && !upgrade.abilities?.length) return;
     previewAttachedUpgrade.value = upgrade;
     attachedUpgradeDrawerOpen.value = true;
 };
@@ -3300,6 +3325,7 @@ const isPastStep = (step: string) => statusOrder.indexOf(props.game.status) > st
                 :is-campaign="isCampaign"
                 :campaign-arsenal="campaign_arsenal ?? []"
                 :campaign-owned-equipment="campaign_owned_equipment ?? []"
+                :campaign-totem="campaign_totem ?? null"
                 :submitting="submitting"
                 :my-slot="mySlot"
                 :opponent-slot="opponentSlot"
@@ -4560,7 +4586,24 @@ const isPastStep = (step: string) => statusOrder.indexOf(props.game.status) > st
                                             :show-collection="false"
                                         />
                                     </div>
-                                    <!-- Campaign Leader/Totem (pg 31, 52) have no card art — render the JSON stat block instead. -->
+                                    <!-- Campaign Leader/Totem (pg 31, 52) — server-rendered card image, once generated. -->
+                                    <div
+                                        v-else-if="expandedMyCards.has(member.id) && member.custom_character?.front_image"
+                                        class="mt-2 overflow-hidden [&_img]:max-h-[70dvh] [&_img]:w-auto [&_img]:object-contain xl:[&_img]:max-h-[50dvh]"
+                                    >
+                                        <CharacterCardView
+                                            :miniature="{
+                                                id: member.custom_character.id,
+                                                display_name: member.custom_character.display_name,
+                                                slug: '',
+                                                front_image: member.custom_character.front_image,
+                                                back_image: member.custom_character.back_image,
+                                            }"
+                                            :show-link="false"
+                                            :show-collection="false"
+                                        />
+                                    </div>
+                                    <!-- No image generated yet — render the JSON stat block instead. -->
                                     <div
                                         v-else-if="expandedMyCards.has(member.id) && hasCustomCharacterCard(member)"
                                         class="mt-2 space-y-2 overflow-hidden"
@@ -5032,7 +5075,24 @@ const isPastStep = (step: string) => statusOrder.indexOf(props.game.status) > st
                                             :show-collection="false"
                                         />
                                     </div>
-                                    <!-- Campaign Leader/Totem (pg 31, 52) have no card art — render the JSON stat block instead. -->
+                                    <!-- Campaign Leader/Totem (pg 31, 52) — server-rendered card image, once generated. -->
+                                    <div
+                                        v-else-if="expandedOpponentCards.has(member.id) && member.custom_character?.front_image"
+                                        class="mt-2 overflow-hidden [&_img]:max-h-[70dvh] [&_img]:w-auto [&_img]:object-contain xl:[&_img]:max-h-[50dvh]"
+                                    >
+                                        <CharacterCardView
+                                            :miniature="{
+                                                id: member.custom_character.id,
+                                                display_name: member.custom_character.display_name,
+                                                slug: '',
+                                                front_image: member.custom_character.front_image,
+                                                back_image: member.custom_character.back_image,
+                                            }"
+                                            :show-link="false"
+                                            :show-collection="false"
+                                        />
+                                    </div>
+                                    <!-- No image generated yet — render the JSON stat block instead. -->
                                     <div
                                         v-else-if="expandedOpponentCards.has(member.id) && hasCustomCharacterCard(member)"
                                         class="mt-2 space-y-2 overflow-hidden"

--- a/resources/views/PDF/BonanzaDeck.blade.php
+++ b/resources/views/PDF/BonanzaDeck.blade.php
@@ -90,7 +90,8 @@
         foreach ($action->triggers as $t) {
             $tsuit = '';
             if ($t->suits) foreach (explode(' ', $t->suits) as $s) if (isset($glyphs[strtolower($s)])) $tsuit .= '<span class="gi">' . $glyphs[strtolower($s)] . '</span>';
-            $h .= '<div class="trig">' . $tsuit . ' <b>' . e($t->name) . ':</b> ' . $renderTokens($t->description) . '</div>';
+            $tstone = $t->stone_cost ? str_repeat('<span class="gi">s</span>', $t->stone_cost) . ' ' : '';
+            $h .= '<div class="trig">' . $tsuit . $tstone . ' <b>' . e($t->name) . ':</b> ' . $renderTokens($t->description) . '</div>';
         }
         return $h . '</div>';
     };
@@ -110,8 +111,9 @@
         }
         foreach ($actions as $a) $h .= $renderAction($a);
         foreach ($triggers as $t) {
-            $tsuit = '';
-            $h .= '<div class="abil"><b>' . e($t->name) . ':</b> ' . $renderTokens($t->description) . '</div>';
+            $tsuit = $renderGlyphList($t->suits);
+            $tstone = $t->stone_cost ? str_repeat('<span class="gi">s</span>', $t->stone_cost) . ' ' : '';
+            $h .= '<div class="abil">' . $tsuit . $tstone . '<b>' . e($t->name) . ':</b> ' . $renderTokens($t->description) . '</div>';
         }
         return $h;
     };

--- a/routes/web.php
+++ b/routes/web.php
@@ -270,6 +270,10 @@ Route::prefix('tools')->name('tools.')->group(function () {
     Route::prefix('card-creator')->name('card_creator.')->group(function () {
         Route::get('/share/{shareCode}', [CustomCharacterController::class, 'share'])->name('share');
         Route::get('/upgrades/share/{shareCode}', [CustomUpgradeController::class, 'share'])->name('upgrades.share');
+        // Headless-Chrome capture target for App\Services\Campaign\LeaderCardImageGenerator —
+        // bare front/back faces only, no page chrome. Public/unauthenticated like `share`
+        // above (same unguessable share_code trust model), hit only by the queue worker.
+        Route::get('/capture/{shareCode}', [CustomCharacterController::class, 'capture'])->name('capture');
 
         Route::middleware('auth')->group(function () {
             Route::get('/', [CustomCharacterController::class, 'index'])->name('index');

--- a/tests/Feature/Campaign/AftermathTest.php
+++ b/tests/Feature/Campaign/AftermathTest.php
@@ -1084,6 +1084,54 @@ it('Phase 4 rejects a second Summoning Advancement for the same leader', functio
     expect(\App\Models\Campaign\CampaignLeaderAdvancement::count())->toBe(1); // no second row
 });
 
+it('Phase 4 Summoning Advancement can be routed to the Totem instead of the Leader', function () {
+    [$user, , $crew, $game] = aftermathFixture();
+    $aftermath = CampaignAftermath::factory()->create([
+        'campaign_game_id' => $game->id,
+        'campaign_crew_id' => $crew->id,
+        'current_phase' => 4,
+        'hand_drawn' => [],
+    ]);
+    $leader = buildLeaderFor($crew, $user);
+    $totem = \App\Models\CustomCharacter::create([
+        'user_id' => $user->id,
+        'campaign_crew_id' => $crew->id,
+        'is_campaign_totem' => true,
+        'current' => true,
+        'name' => 'Test Totem',
+        'display_name' => 'Test Totem',
+        'faction' => \App\Enums\FactionEnum::Resurrectionists->value,
+        'health' => 6, 'defense' => 5, 'willpower' => 5, 'speed' => 6, 'base' => 30,
+    ]);
+    $summoning = \App\Models\Action::factory()->create([
+        'name' => 'Test Summoning',
+        'game_mode_type' => \App\Enums\GameModeTypeEnum::Campaign->value,
+        'campaign_advancement_kind' => 'summoning',
+    ]);
+
+    $this->actingAs($user)
+        ->post(route('campaigns.aftermaths.advance-leader', $aftermath), [
+            'bruiser_killed_non_peon' => false,
+            'strategist_interacted' => false,
+            'lost' => false,
+            'advancements' => [
+                [
+                    'source_table' => 'summoning',
+                    'catalog_id' => $summoning->id,
+                    'applied_to_custom_character_id' => $totem->id,
+                    // Tier-3 box (the default XP track has a 3 at index 4).
+                    'position_in_xp_track' => 4,
+                ],
+            ],
+        ])
+        ->assertRedirect();
+
+    $recorded = \App\Models\Campaign\CampaignLeaderAdvancement::sole();
+    expect($recorded->applied_to_custom_character_id)->toBe($totem->id);
+    expect(collect($totem->fresh()->actions)->pluck('name'))->toContain('Test Summoning');
+    expect(collect($leader->fresh()->actions)->pluck('name'))->not->toContain('Test Summoning');
+});
+
 it('Phase 4 Totem Advancement no longer requires a flip value (flip-gating removed for now)', function () {
     [$user, , $crew, $game] = aftermathFixture();
     $aftermath = CampaignAftermath::factory()->create([
@@ -1124,6 +1172,49 @@ it('Phase 4 Totem Advancement no longer requires a flip value (flip-gating remov
         ])
         ->assertRedirect();
     expect($aftermath->fresh()->current_phase)->toBe(5);
+});
+
+it('Phase 4 Totem Advancement carries the template ability body under the description key', function () {
+    [$user, , $crew, $game] = aftermathFixture();
+    $aftermath = CampaignAftermath::factory()->create([
+        'campaign_game_id' => $game->id,
+        'campaign_crew_id' => $crew->id,
+        'current_phase' => 4,
+        'hand_drawn' => [],
+    ]);
+    buildLeaderFor($crew, $user);
+    $totemTemplate = \App\Models\CustomCharacter::create([
+        'user_id' => $user->id,
+        'is_campaign_totem_template' => true,
+        'name' => 'Wisp',
+        'display_name' => 'Wisp',
+        'faction' => \App\Enums\FactionEnum::Arcanists->value,
+        'health' => 4,
+        'defense' => 4,
+        'willpower' => 4,
+        'speed' => 5,
+        'base' => 30,
+    ]);
+    $ability = \App\Models\Ability::factory()->create(['name' => 'Test Totem Ability', 'description' => 'Does a totem thing.']);
+    $totemTemplate->campaignTotemAbilities()->attach($ability->id);
+
+    $this->actingAs($user)
+        ->post(route('campaigns.aftermaths.advance-leader', $aftermath), [
+            'bruiser_killed_non_peon' => false,
+            'strategist_interacted' => false,
+            'lost' => false,
+            'advancements' => [[
+                'source_table' => 'totem',
+                'catalog_id' => $totemTemplate->id,
+                'position_in_xp_track' => 4,
+            ]],
+        ])
+        ->assertRedirect();
+
+    $totem = \App\Models\CustomCharacter::where('is_campaign_totem', true)->where('campaign_crew_id', $crew->id)->firstOrFail();
+    expect($totem->abilities[0]['name'])->toBe('Test Totem Ability');
+    expect($totem->abilities[0]['description'])->toBe('Does a totem thing.');
+    expect($totem->abilities[0])->not->toHaveKey('body');
 });
 
 it('Phase 4 Totem Advancement inherits the leader\'s keywords', function () {
@@ -2080,8 +2171,49 @@ it('Phase 6 review screen: phase_summary rolls up what Phases 1-5 already commit
             ->where('phase_summary.barter_total_cc', 3)
             ->where('phase_summary.advancements.0.table', 'Attack Mod')
             ->where('phase_summary.advancements.0.name', 'Test Attack Mod')
+            ->where('phase_summary.advancements.0.target', 'TestLeader')
             ->has('phase_summary.doctor_attempts', 1)
             ->where('phase_summary.doctor_attempts.0.outcome', 'Removed')
+            ->etc());
+});
+
+it('Phase 6 review screen: phase_summary resolves the Totem/Equipment target for a rerouted advancement', function () {
+    [$user, , $crew, $game] = aftermathFixture();
+    $leader = buildLeaderFor($crew, $user);
+    $totem = \App\Models\CustomCharacter::create([
+        'user_id' => $user->id,
+        'campaign_crew_id' => $crew->id,
+        'is_campaign_totem' => true,
+        'current' => true,
+        'name' => 'Test Totem',
+        'display_name' => 'Test Totem',
+        'faction' => \App\Enums\FactionEnum::Resurrectionists->value,
+        'health' => 6, 'defense' => 5, 'willpower' => 5, 'speed' => 6, 'base' => 30,
+    ]);
+    $aftermath = CampaignAftermath::factory()->create([
+        'campaign_game_id' => $game->id,
+        'campaign_crew_id' => $crew->id,
+        'current_phase' => 6,
+        'hand_drawn' => [],
+    ]);
+    $attackMod = \App\Models\Campaign\AdvancementAttackMod::factory()->create(['name' => 'Totem-routed Trigger']);
+    \App\Models\Campaign\CampaignLeaderAdvancement::create([
+        'custom_character_id' => $leader->id,
+        'source_aftermath_id' => $aftermath->id,
+        'source_table' => \App\Enums\Campaign\AdvancementTableEnum::AttackMod->value,
+        'advancement_catalog_id' => $attackMod->id,
+        'applied_to_custom_character_id' => $totem->id,
+        'applied_to_action_index' => -1,
+        'position_in_xp_track' => 3,
+        'acquired_at' => now(),
+    ]);
+
+    $this->actingAs($user)
+        ->get(route('campaigns.aftermaths.show', $aftermath))
+        ->assertOk()
+        ->assertInertia(fn ($page) => $page
+            ->where('phase_summary.advancements.0.name', 'Totem-routed Trigger')
+            ->where('phase_summary.advancements.0.target', 'Test Totem')
             ->etc());
 });
 

--- a/tests/Feature/Campaign/ArsenalSheetTest.php
+++ b/tests/Feature/Campaign/ArsenalSheetTest.php
@@ -295,7 +295,7 @@ it('exposes Leader/Totem injuries in the payload and counts them toward Campaign
         'faction' => \App\Enums\FactionEnum::Resurrectionists->value,
         'health' => 4, 'defense' => 4, 'willpower' => 4, 'speed' => 5, 'base' => 30,
     ]);
-    $injury = \App\Models\Upgrade::factory()->campaignInjury()->create(['name' => 'Concussed']);
+    $injury = \App\Models\Upgrade::factory()->campaignInjury()->create(['name' => 'Concussed', 'description' => 'Take a nap.']);
     \Illuminate\Support\Facades\DB::table('campaign_arsenal_model_injuries')->insert([
         ['custom_character_id' => $leader->id, 'injury_upgrade_id' => $injury->id, 'created_at' => now(), 'updated_at' => now()],
         ['custom_character_id' => $totem->id, 'injury_upgrade_id' => $injury->id, 'created_at' => now(), 'updated_at' => now()],
@@ -305,8 +305,10 @@ it('exposes Leader/Totem injuries in the payload and counts them toward Campaign
         ->get(route('campaigns.crews.arsenal.show', [$campaign, $crew->share_code]))
         ->assertOk()
         ->assertInertia(fn ($page) => $page
-            ->where('leader.injury_names', ['Concussed'])
-            ->where('totem.injury_names', ['Concussed'])
+            ->where('leader.injury_names.0.name', 'Concussed')
+            ->where('leader.injury_names.0.description', 'Take a nap.')
+            ->where('totem.injury_names.0.name', 'Concussed')
+            ->where('totem.injury_names.0.description', 'Take a nap.')
             ->where('campaign_rating.injury_count', 2)
         );
 

--- a/tests/Feature/Campaign/CampaignGameIntegrationTest.php
+++ b/tests/Feature/Campaign/CampaignGameIntegrationTest.php
@@ -411,6 +411,62 @@ it('submitCampaignCrew rejects an equipment_assignments target outside the Leade
     expect(\App\Models\GameCrewMember::where('game_id', $game->id)->exists())->toBeFalse();
 });
 
+it('submitCampaignCrew assigns owned equipment to a Tier-3 Totem', function () {
+    [$userA, , , $crewA, , $game] = campaignGameSetup();
+
+    CustomCharacter::create([
+        'user_id' => $userA->id,
+        'campaign_crew_id' => $crewA->id,
+        'is_campaign_totem' => true,
+        'current' => true,
+        'share_code' => 'totem-test-001',
+        'name' => 'Test Totem',
+        'display_name' => 'Test Totem',
+        'slug' => 'test-totem',
+        'faction' => FactionEnum::Arcanists->value,
+        'health' => 6, 'defense' => 5, 'willpower' => 5, 'speed' => 6,
+    ]);
+
+    $equipmentUpgrade = \App\Models\Upgrade::factory()->campaignEquipment()->create(['name' => 'Totem Trinket']);
+    \App\Models\Campaign\CampaignEquipment::factory()->create(['campaign_crew_id' => $crewA->id, 'equipment_upgrade_id' => $equipmentUpgrade->id]);
+
+    $this->actingAs($userA)
+        ->postJson(route('games.setup.campaign-crew', $game->uuid), [
+            'character_ids' => [],
+            'equipment_assignments' => [
+                ['equipment_id' => $equipmentUpgrade->id, 'target' => 'totem'],
+            ],
+        ])
+        ->assertOk();
+
+    $player = $game->players()->where('user_id', $userA->id)->first();
+    $totemMember = \App\Models\GameCrewMember::where('game_id', $game->id)
+        ->where('game_player_id', $player->id)
+        ->where('hiring_category', 'totem')
+        ->first();
+
+    expect($totemMember)->not->toBeNull();
+    expect(collect($totemMember->attached_upgrades)->pluck('name')->all())->toBe(['Totem Trinket']);
+});
+
+it('submitCampaignCrew rejects a totem equipment assignment when the crew has no Totem yet', function () {
+    [$userA, , , $crewA, , $game] = campaignGameSetup();
+
+    $equipmentUpgrade = \App\Models\Upgrade::factory()->campaignEquipment()->create();
+    \App\Models\Campaign\CampaignEquipment::factory()->create(['campaign_crew_id' => $crewA->id, 'equipment_upgrade_id' => $equipmentUpgrade->id]);
+
+    $this->actingAs($userA)
+        ->postJson(route('games.setup.campaign-crew', $game->uuid), [
+            'character_ids' => [],
+            'equipment_assignments' => [
+                ['equipment_id' => $equipmentUpgrade->id, 'target' => 'totem'],
+            ],
+        ])
+        ->assertStatus(422);
+
+    expect(\App\Models\GameCrewMember::where('game_id', $game->id)->exists())->toBeFalse();
+});
+
 it('submitCampaignCrew rejects assigning more copies of an equipment than the crew owns', function () {
     [$userA, , , $crewA, , $game] = campaignGameSetup();
 
@@ -533,6 +589,32 @@ it('character_upgrades at InProgress offers the campaign crew\'s own earned equi
                 'plentiful' => 2,
                 'power_bar_count' => $owned->power_bar_count,
                 'description' => $owned->description,
+                'actions' => [],
+                'abilities' => [],
             ]])
+        );
+});
+
+it('character_upgrades at InProgress carries the equipment\'s granted actions/abilities in full, not just the description', function () {
+    [$userA, , , $crewA, , $game] = campaignGameSetup();
+    $game->update(['status' => GameStatusEnum::InProgress->value]);
+
+    $owned = \App\Models\Upgrade::factory()->campaignEquipment()->create(['name' => 'Owned Trinket']);
+    \App\Models\Campaign\CampaignEquipment::factory()->create([
+        'campaign_crew_id' => $crewA->id,
+        'equipment_upgrade_id' => $owned->id,
+    ]);
+    $action = \App\Models\Action::factory()->create(['name' => 'Granted Slash', 'type' => 'attack', 'stat' => 5]);
+    $owned->actions()->attach($action->id, ['is_signature_action' => true]);
+    $ability = \App\Models\Ability::factory()->create(['name' => 'Granted Ward']);
+    $owned->abilities()->attach($ability->id);
+
+    $this->actingAs($userA)
+        ->get(route('games.show', $game->uuid))
+        ->assertOk()
+        ->assertInertia(fn ($page) => $page
+            ->where('character_upgrades.0.actions.0.name', 'Granted Slash')
+            ->where('character_upgrades.0.actions.0.is_signature', true)
+            ->where('character_upgrades.0.abilities.0.name', 'Granted Ward')
         );
 });

--- a/tests/Feature/Campaign/LeaderCardImageTest.php
+++ b/tests/Feature/Campaign/LeaderCardImageTest.php
@@ -1,0 +1,200 @@
+<?php
+
+use App\Enums\Campaign\LeaderArchetypeEnum;
+use App\Enums\Campaign\LeaderTagEnum;
+use App\Enums\FactionEnum;
+use App\Enums\PermissionEnum;
+use App\Jobs\Campaign\GenerateLeaderCardImage;
+use App\Models\Campaign\Campaign;
+use App\Models\Campaign\CampaignCrew;
+use App\Models\Campaign\CampaignLeaderAdvancement;
+use App\Models\Campaign\CampaignPlayer;
+use App\Models\CustomCharacter;
+use App\Models\User;
+use Illuminate\Support\Facades\Bus;
+use Spatie\Permission\Models\Permission;
+
+beforeEach(function () {
+    foreach (PermissionEnum::cases() as $perm) {
+        Permission::firstOrCreate(['name' => $perm->value]);
+    }
+});
+
+function lciUser(): User
+{
+    $user = User::factory()->create(['email_verified_at' => now()]);
+    $user->givePermissionTo(PermissionEnum::UseCampaignMode->value);
+
+    return $user;
+}
+
+function lciCrew(User $user): CampaignCrew
+{
+    $campaign = Campaign::factory()->create(['organizer_user_id' => $user->id]);
+    CampaignPlayer::factory()->organizer()->create(['campaign_id' => $campaign->id, 'user_id' => $user->id]);
+
+    return CampaignCrew::factory()->create(['campaign_id' => $campaign->id, 'user_id' => $user->id]);
+}
+
+/** @return array{Campaign, CampaignCrew, CustomCharacter} a leader with earned tier-1 (index 0) and tier-2 (index 2) boxes. */
+function lciLeaderWithEarnedBox(User $user): array
+{
+    $crew = lciCrew($user);
+    $track = CustomCharacter::defaultXpTrack();
+    $track[0]['filled'] = true;
+    $track[2]['filled'] = true;
+
+    $leader = CustomCharacter::create([
+        'user_id' => $user->id,
+        'campaign_crew_id' => $crew->id,
+        'is_campaign_leader' => true,
+        'current' => true,
+        'name' => 'Card Leader',
+        'faction' => FactionEnum::Guild->value,
+        'station' => 'master',
+        'health' => 12, 'defense' => 5, 'willpower' => 6, 'speed' => 5,
+        'xp_track' => $track,
+    ]);
+
+    return [$crew->campaign, $crew, $leader];
+}
+
+it('queues a card regeneration when a new Leader is saved via the Leader Builder', function () {
+    Bus::fake();
+    $user = lciUser();
+    $crew = lciCrew($user);
+    $faction = FactionEnum::Guild;
+    $kw1 = \App\Models\Keyword::factory()->create();
+    \App\Models\Character::factory()->create(['faction' => $faction])->keywords()->attach($kw1);
+    $kw2 = \App\Models\Keyword::factory()->create();
+
+    $this->actingAs($user)
+        ->post(route('campaigns.crews.leader.update', [$crew->campaign_id, $crew->share_code]), [
+            'name' => 'New Leader',
+            'archetype' => LeaderArchetypeEnum::Generalist->value,
+            'tag' => LeaderTagEnum::Bruiser->value,
+            'faction' => $faction->value,
+            'keyword_1_id' => $kw1->id, 'keyword_2_id' => $kw2->id,
+            'size' => 2, 'base' => 30,
+            'actions' => [],
+            'abilities' => [],
+        ])
+        ->assertRedirect();
+
+    $leader = CustomCharacter::where('campaign_crew_id', $crew->id)->where('current', true)->firstOrFail();
+    Bus::assertDispatched(GenerateLeaderCardImage::class, fn ($job) => $job->customCharacterId === $leader->id);
+});
+
+it('queues a card regeneration when an advancement is logged directly from the Arsenal Sheet', function () {
+    $user = lciUser();
+    [$campaign, $crew, $leader] = lciLeaderWithEarnedBox($user);
+    // A bespoke (no ability_id/is_joker) Ability advancement unconditionally
+    // appends to the target's abilities[] and saves — unlike AttackMod/
+    // TacticalMod, it needs no applied_to_action_index to take effect.
+    $ability = \App\Models\Campaign\AdvancementAbility::factory()->create(['talent_name' => 'Card Test Ability']);
+
+    Bus::fake();
+    $this->actingAs($user)
+        ->post(route('campaigns.crews.leader.advancements.store', [$campaign->id, $crew->share_code]), [
+            'position_in_xp_track' => 2,
+            'source_table' => 'ability',
+            'catalog_id' => $ability->id,
+        ])
+        ->assertRedirect();
+
+    Bus::assertDispatched(GenerateLeaderCardImage::class, fn ($job) => $job->customCharacterId === $leader->id);
+});
+
+it('queues a card regeneration when a logged advancement is removed', function () {
+    $user = lciUser();
+    [$campaign, $crew, $leader] = lciLeaderWithEarnedBox($user);
+    $ability = \App\Models\Campaign\AdvancementAbility::factory()->create(['talent_name' => 'Card Test Ability']);
+
+    $this->actingAs($user)->post(route('campaigns.crews.leader.advancements.store', [$campaign->id, $crew->share_code]), [
+        'position_in_xp_track' => 2,
+        'source_table' => 'ability',
+        'catalog_id' => $ability->id,
+    ]);
+    $logged = CampaignLeaderAdvancement::where('custom_character_id', $leader->id)->firstOrFail();
+
+    Bus::fake();
+    $this->actingAs($user)
+        ->delete(route('campaigns.crews.leader.advancements.destroy', [$campaign->id, $crew->share_code, $logged]))
+        ->assertRedirect();
+
+    Bus::assertDispatched(GenerateLeaderCardImage::class, fn ($job) => $job->customCharacterId === $leader->id);
+});
+
+it('queues a card regeneration for a Totem created via an Advance Leader advancement', function () {
+    Bus::fake();
+    $user = lciUser();
+    $crew = lciCrew($user);
+    $leader = CustomCharacter::create([
+        'user_id' => $user->id,
+        'campaign_crew_id' => $crew->id,
+        'is_campaign_leader' => true,
+        'current' => true,
+        'name' => 'TestLeader',
+        'faction' => FactionEnum::Resurrectionists->value,
+        'health' => 14, 'defense' => 5, 'willpower' => 5, 'speed' => 6, 'base' => 30,
+    ]);
+    $opponent = CampaignCrew::factory()->create(['campaign_id' => $crew->campaign_id]);
+    $game = \App\Models\Campaign\CampaignGame::factory()->create([
+        'campaign_id' => $crew->campaign_id,
+        'crew_a_id' => $crew->id,
+        'crew_b_id' => $opponent->id,
+    ]);
+    $aftermath = \App\Models\Campaign\CampaignAftermath::factory()->create([
+        'campaign_game_id' => $game->id,
+        'campaign_crew_id' => $crew->id,
+        'current_phase' => 4,
+        'hand_drawn' => [],
+    ]);
+    $totemTemplate = CustomCharacter::create([
+        'user_id' => $user->id,
+        'is_campaign_totem_template' => true,
+        'name' => 'Wisp',
+        'faction' => FactionEnum::Resurrectionists->value,
+        'health' => 3, 'defense' => 4, 'willpower' => 4, 'speed' => 5, 'base' => 30,
+    ]);
+
+    $this->actingAs($user)
+        ->post(route('campaigns.aftermaths.advance-leader', $aftermath), [
+            'bruiser_killed_non_peon' => false,
+            'strategist_interacted' => false,
+            'lost' => false,
+            'advancements' => [[
+                'source_table' => 'totem',
+                'catalog_id' => $totemTemplate->id,
+                'position_in_xp_track' => 4,
+            ]],
+        ])
+        ->assertRedirect();
+
+    $totem = CustomCharacter::where('is_campaign_totem', true)->where('campaign_crew_id', $crew->id)->firstOrFail();
+    Bus::assertDispatched(GenerateLeaderCardImage::class, fn ($job) => $job->customCharacterId === $totem->id);
+});
+
+it('does not queue a card regeneration for an unrelated field change', function () {
+    $user = lciUser();
+    [, , $leader] = lciLeaderWithEarnedBox($user);
+
+    Bus::fake();
+    $leader->update(['notes' => 'Just a note, not a card change.']);
+
+    Bus::assertNotDispatched(GenerateLeaderCardImage::class);
+});
+
+it('does not queue a card regeneration for a non-Campaign homebrew character', function () {
+    $user = lciUser();
+
+    Bus::fake();
+    CustomCharacter::create([
+        'user_id' => $user->id,
+        'name' => 'Homebrew Master',
+        'faction' => FactionEnum::Guild->value,
+        'health' => 10, 'defense' => 5, 'willpower' => 5, 'speed' => 5, 'base' => 30,
+    ]);
+
+    Bus::assertNotDispatched(GenerateLeaderCardImage::class);
+});

--- a/tests/Feature/Tools/BonanzaPrintTest.php
+++ b/tests/Feature/Tools/BonanzaPrintTest.php
@@ -1,7 +1,11 @@
 <?php
 
+use App\Models\Action;
+use App\Models\LootCard;
+use App\Models\Trigger;
 use App\Services\BonanzaDeckPdfGenerator;
 use Illuminate\Support\Facades\Storage;
+use Illuminate\Support\Facades\View;
 
 it('serves the cached print PDF without re-rendering', function () {
     Storage::fake('public');
@@ -14,4 +18,35 @@ it('serves the cached print PDF without re-rendering', function () {
     $resp->assertOk();
     expect($resp->headers->get('content-type'))->toContain('application/pdf');
     expect($resp->getContent())->toStartWith('%PDF');
+});
+
+it('BonanzaDeck Blade renders a soulstone glyph for a stone-cost trigger, both standalone and action-nested', function () {
+    $standaloneTrigger = Trigger::factory()->create(['name' => 'Standalone Trig', 'stone_cost' => 1, 'suits' => null]);
+    $nestedTrigger = Trigger::factory()->create(['name' => 'Nested Trig', 'stone_cost' => 2, 'suits' => null]);
+    $action = Action::factory()->create(['name' => 'Host Action']);
+    $action->triggers()->attach($nestedTrigger->id);
+
+    $card = LootCard::create([
+        'slug' => 'stone-test', 'name' => 'Stone Test', 'suit' => 'crow', 'value' => 1, 'value_label' => '1', 'sort_order' => 1,
+    ]);
+    $card->syncSideTriggers('a', [$standaloneTrigger->id]);
+    $card->syncSideActions('a', [['action_id' => $action->id, 'is_signature_action' => false]]);
+
+    $card->load([
+        'sideAActions.triggers', 'sideBActions.triggers',
+        'sideAAbilities', 'sideBAbilities',
+        'sideATriggers', 'sideBTriggers',
+    ]);
+
+    $html = View::make('PDF.BonanzaDeck', ['cards' => collect([$card])])->render();
+
+    // Two soulstone glyphs for the nested trigger's stone_cost of 2, one for
+    // the standalone trigger's stone_cost of 1 — plus each trigger's name,
+    // right next to the glyphs (not floating elsewhere in the page).
+    expect($html)->toContain('Standalone Trig');
+    expect($html)->toContain('Nested Trig');
+    $standaloneChunk = substr($html, (int) strpos($html, 'Standalone Trig') - 60, 60);
+    $nestedChunk = substr($html, (int) strpos($html, 'Nested Trig') - 80, 80);
+    expect(substr_count($standaloneChunk, '<span class="gi">s</span>'))->toBe(1);
+    expect(substr_count($nestedChunk, '<span class="gi">s</span>'))->toBe(2);
 });


### PR DESCRIPTION
Campaign QA fixes (Log Game/Advance Leader, Arsenal Sheet, Game Tracker, Aftermath review):
- Drop the leftover flip-number label from advancement dropdowns
- Alternate background colors on queued advancement boxes for readability
- Fix Totem ability body JSON key so Totem cards render their granted text
- Allow Summoning advancements to target the Totem, not just the Leader
- Show an inline "borrowed from" master field when a generic Crew Card effect is picked directly from the flat list
- Arsenal Sheet: injuries are clickable and show their rules text
- Game Tracker: fix Crew Card going stale after crew-select partial reload
- Game Tracker: allow Equipment to be assigned to the Totem at crew select
- Game Tracker: render Equipment's full granted actions/abilities, not just its flavor description
- Log Game review: show who an advancement actually landed on (Leader vs. rerouted Totem/Equipment), and adjust the "no new injuries" wording

Server-generated Leader/Totem card images:
- New front/back/combination image columns on custom_characters, generated via a headless-Chrome capture of the real CardFrontFace/CardBackFace Vue components (not a hand-duplicated Blade template), mirroring the existing Miniature/Upgrade image pattern
- CustomCharacterObserver dispatches regeneration whenever a Campaign Leader/Totem's card-relevant fields change, covering every mutation path (Leader Builder, Advance Leader, direct advancement logging/removal, Totem creation) from a single hook
- Arsenal Sheet and Game Tracker both show the saved image via the same flip-card widget used for real Characters, falling back to the live client-rendered card until the first image lands
- Arsenal Sheet's card download button now serves the saved image directly

Also fixes the Bonanza Brawl print PDF: stone-cost triggers weren't rendering their soulstone icon (a gap in the hand-maintained Blade template, not present in the on-screen reference page).