### PR TITLE
fix: Campaign QA round — Leader card regen, arsenal multi-hire, crew …

### DIFF
--- a/app/Http/Controllers/Campaign/CampaignController.php
+++ b/app/Http/Controllers/Campaign/CampaignController.php
@@ -11,6 +11,7 @@ use App\Http\Requests\Campaign\UpdateCampaignRequest;
 use App\Models\Campaign\Campaign;
 use App\Models\Campaign\CampaignCrew;
 use App\Models\Campaign\CampaignPlayer;
+use App\Models\Game;
 use App\Traits\Campaign\AddsCampaignMember;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\DB;
@@ -116,7 +117,33 @@ class CampaignController extends Controller
             'campaign' => $campaign,
             'is_organizer' => $request->user()->can('update', $campaign),
             'all_arsenals_complete' => ! $incompleteCrew,
+            'active_solo_game' => $campaign->is_solo ? $this->activeSoloGame($campaign, $request->user()->id) : null,
         ]);
+    }
+
+    /**
+     * The user's own not-yet-finished live game for this solo campaign, if
+     * one exists — Play Live otherwise mints a brand new Game every click,
+     * orphaning whatever the player was mid-way through. Lets the hub offer
+     * "Resume" instead of silently abandoning it.
+     *
+     * @return array{uuid: string, status: string, started_at: string|null}|null
+     */
+    private function activeSoloGame(Campaign $campaign, int $userId): ?array
+    {
+        $game = Game::query()
+            ->active()
+            ->where('creator_id', $userId)
+            ->where('is_solo', true)
+            ->whereHas('campaignGame', fn ($q) => $q->where('campaign_id', $campaign->id))
+            ->latest('id')
+            ->first(['id', 'uuid', 'status', 'started_at']);
+
+        return $game ? [
+            'uuid' => $game->uuid,
+            'status' => $game->status->value,
+            'started_at' => $game->started_at?->toIso8601String(),
+        ] : null;
     }
 
     public function settings(Request $request, Campaign $campaign)

--- a/app/Http/Controllers/Game/GameController.php
+++ b/app/Http/Controllers/Game/GameController.php
@@ -680,6 +680,12 @@ class GameController extends Controller
                 $isOok = ! $sharesKeyword && ! $isVersatile;
 
                 return [
+                    // The arsenal row's own id — not just character_id — so
+                    // owning several copies of the same catalog Character
+                    // (each its own CampaignArsenalModel row) can be selected
+                    // and hired individually instead of collapsing into one
+                    // shared toggle. See GameCrewSelectPanel.vue.
+                    'id' => $m->id,
                     'character_id' => $m->character_id,
                     'name' => $char->display_name ?? $char->name,
                     'faction' => $char->getRawOriginal('faction'),

--- a/app/Http/Controllers/Game/GameSetupController.php
+++ b/app/Http/Controllers/Game/GameSetupController.php
@@ -280,8 +280,12 @@ class GameSetupController extends Controller
         }
 
         $validated = $request->validate([
-            'character_ids' => ['present', 'array'],
-            'character_ids.*' => ['integer', 'exists:characters,id'],
+            // CampaignArsenalModel row ids, not Character catalog ids — one
+            // entry per physical model hired, so owning several copies of the
+            // same catalog Character hires exactly the ones picked instead of
+            // every owned copy at once.
+            'arsenal_model_ids' => ['present', 'array'],
+            'arsenal_model_ids.*' => ['integer', 'exists:campaign_arsenal_models,id'],
             // Owned equipment (pg 19) optionally attached to a specific hire
             // (or the Leader) at selection time, instead of only during play.
             'equipment_assignments' => ['nullable', 'array'],
@@ -289,7 +293,7 @@ class GameSetupController extends Controller
             'equipment_assignments.*.target' => ['required', 'string'],
         ]);
 
-        $characterIds = array_map('intval', $validated['character_ids']);
+        $arsenalModelIds = array_map('intval', $validated['arsenal_model_ids']);
 
         $userId = Auth::id();
         $campaignGame = \App\Models\Campaign\CampaignGame::query()
@@ -324,16 +328,18 @@ class GameSetupController extends Controller
             return response()->json(['error' => 'Campaign crew not found — ensure you have an active campaign with a built leader for your faction.'], 422);
         }
 
-        if (! empty($characterIds)) {
-            $arsenalIds = \App\Models\Campaign\CampaignArsenalModel::query()
-                ->where('campaign_crew_id', $campaignCrew->id)
-                ->active()
-                ->pluck('character_id')
-                ->all();
+        $ownedArsenalModels = \App\Models\Campaign\CampaignArsenalModel::query()
+            ->where('campaign_crew_id', $campaignCrew->id)
+            ->active()
+            ->get(['id', 'character_id'])
+            ->keyBy('id');
 
-            $outside = array_diff($characterIds, $arsenalIds);
+        if (! empty($arsenalModelIds)) {
+            $outside = array_diff($arsenalModelIds, $ownedArsenalModels->keys()->all());
             if (! empty($outside)) {
-                $names = Character::whereIn('id', $outside)->pluck('display_name')->implode(', ');
+                $names = \App\Models\Campaign\CampaignArsenalModel::whereIn('id', $outside)->with('character:id,display_name')->get()
+                    ->map(fn ($m) => $m->character->display_name ?? "#{$m->id}")
+                    ->implode(', ');
 
                 return response()->json(['error' => "Not in your campaign arsenal: {$names}"], 422);
             }
@@ -344,14 +350,14 @@ class GameSetupController extends Controller
             return response()->json(['error' => 'Build your campaign leader before selecting crew'], 422);
         }
 
-        $equipmentByTarget = $this->resolveEquipmentAssignments($campaignCrew, $characterIds, $validated['equipment_assignments'] ?? []);
+        $equipmentByTarget = $this->resolveEquipmentAssignments($campaignCrew, $arsenalModelIds, $validated['equipment_assignments'] ?? []);
         if (is_string($equipmentByTarget)) {
             return response()->json(['error' => $equipmentByTarget], 422);
         }
 
-        DB::transaction(function () use ($player, $game, $characterIds, $equipmentByTarget) {
+        DB::transaction(function () use ($player, $game, $arsenalModelIds, $equipmentByTarget) {
             $player->update(['crew_skipped' => true]);
-            $this->copyCrewToGame($game, $player, null, $characterIds, $equipmentByTarget);
+            $this->copyCrewToGame($game, $player, null, $arsenalModelIds, $equipmentByTarget);
 
             $totalSpent = GameCrewMember::where('game_id', $game->id)
                 ->where('game_player_id', $player->id)
@@ -634,10 +640,14 @@ class GameSetupController extends Controller
     }
 
     /**
-     * @param  array<int, int>  $campaignCharacterIds
-     * @param  array<string, array<int, array<string, mixed>>>  $equipmentByTarget  keyed by 'leader' or a character_id
+     * @param  array<int, int>  $campaignArsenalModelIds  CampaignArsenalModel row ids — one per
+     *                                                    physical model hired, so owning several
+     *                                                    copies of the same catalog Character
+     *                                                    hires exactly the ones selected rather
+     *                                                    than every owned copy.
+     * @param  array<int|string, array<int, array<string, mixed>>>  $equipmentByTarget  keyed by 'leader', 'totem', or a CampaignArsenalModel id
      */
-    private function copyCrewToGame(Game $game, GamePlayer $player, ?CrewBuild $crewBuild, array $campaignCharacterIds = [], array $equipmentByTarget = []): void
+    private function copyCrewToGame(Game $game, GamePlayer $player, ?CrewBuild $crewBuild, array $campaignArsenalModelIds = [], array $equipmentByTarget = []): void
     {
         // Delete existing crew members for this player (in case of re-selection)
         GameCrewMember::where('game_id', $game->id)
@@ -747,29 +757,34 @@ class GameSetupController extends Controller
                 ->toArray();
 
             // Campaign crews hire from CampaignArsenalModel (real Character catalog
-            // rows), never a CrewBuild — the selected arsenal IDs come in directly
-            // from submitCampaignCrew rather than $crewBuild->crew_data.
-            $crewCharacters = Character::with('miniatures', 'keywords', 'characteristics')
-                ->whereIn('id', $campaignCharacterIds)
-                ->get()
-                ->keyBy('id');
-
-            // Injuries are attached per specific arsenal-model row (not per
-            // catalog character), so resolve which row backs each selected hire.
-            $arsenalModelsByCharacterId = $campaignCrew
+            // rows), never a CrewBuild — the selected arsenal row IDs come in
+            // directly from submitCampaignCrew rather than $crewBuild->crew_data.
+            // Keyed by the arsenal row's own id (not character_id) so owning
+            // several copies of the same catalog Character hires exactly the
+            // rows the player selected, each with its own injuries.
+            $arsenalModels = $campaignCrew
                 ? \App\Models\Campaign\CampaignArsenalModel::query()
                     ->where('campaign_crew_id', $campaignCrew->id)
-                    ->whereIn('character_id', $campaignCharacterIds)
+                    ->whereIn('id', $campaignArsenalModelIds)
                     ->active()
                     ->get()
-                    ->keyBy('character_id')
+                    ->keyBy('id')
                 : collect();
+
+            $crewCharacters = Character::with('miniatures', 'keywords', 'characteristics')
+                ->whereIn('id', $arsenalModels->pluck('character_id')->unique())
+                ->get()
+                ->keyBy('id');
 
             $miniatureSelections = [];
             $miniatureIndexes = [];
 
-            foreach ($campaignCharacterIds as $charId) {
-                $character = $crewCharacters->get($charId);
+            foreach ($campaignArsenalModelIds as $arsenalModelId) {
+                $arsenalModel = $arsenalModels->get($arsenalModelId);
+                if (! $arsenalModel) {
+                    continue;
+                }
+                $character = $crewCharacters->get($arsenalModel->character_id);
                 if (! $character) {
                     continue;
                 }
@@ -779,9 +794,8 @@ class GameSetupController extends Controller
                 $category = $sharesKeyword ? 'in-keyword' : ($isVersatile ? 'versatile' : 'ook');
                 $effectiveCost = $category === 'ook' ? ($character->cost + 1) : $character->cost;
 
-                $arsenalModel = $arsenalModelsByCharacterId->get($charId);
-                $injuryUpgrades = $arsenalModel ? $this->injuryUpgrades('campaign_arsenal_model_id', $arsenalModel->id) : [];
-                $attachedUpgrades = array_merge($injuryUpgrades, $equipmentByTarget[$charId] ?? []);
+                $injuryUpgrades = $this->injuryUpgrades('campaign_arsenal_model_id', $arsenalModel->id);
+                $attachedUpgrades = array_merge($injuryUpgrades, $equipmentByTarget[$arsenalModel->id] ?? []);
 
                 $this->createCrewMember($game, $player, $character, $category, $effectiveCost, $sortOrder++, $miniatureSelections, $miniatureIndexes, $attachedUpgrades);
             }
@@ -892,11 +906,11 @@ class GameSetupController extends Controller
      * your crew... without cost"). Returns an error string instead of the map
      * if any assignment is invalid.
      *
-     * @param  array<int, int>  $characterIds
+     * @param  array<int, int>  $arsenalModelIds  CampaignArsenalModel row ids being hired this game
      * @param  array<int, array{equipment_id: int, target: string}>  $assignments
-     * @return array<string, array<int, array<string, mixed>>>|string
+     * @return array<int|string, array<int, array<string, mixed>>>|string
      */
-    private function resolveEquipmentAssignments(\App\Models\Campaign\CampaignCrew $crew, array $characterIds, array $assignments): array|string
+    private function resolveEquipmentAssignments(\App\Models\Campaign\CampaignCrew $crew, array $arsenalModelIds, array $assignments): array|string
     {
         if (empty($assignments)) {
             return [];
@@ -919,7 +933,7 @@ class GameSetupController extends Controller
                 if (! $crew->totem) {
                     return "Equipment can't be assigned to a Totem — this crew hasn't unlocked one yet.";
                 }
-            } elseif ($target !== 'leader' && ! in_array($target, $characterIds, true)) {
+            } elseif ($target !== 'leader' && ! in_array($target, $arsenalModelIds, true)) {
                 return 'Equipment can only be assigned to the Leader, Totem, or a model you\'re hiring this game.';
             }
 

--- a/app/Models/Game.php
+++ b/app/Models/Game.php
@@ -6,6 +6,7 @@ use App\Enums\DeploymentEnum;
 use App\Enums\GameFormatEnum;
 use App\Enums\GameStatusEnum;
 use App\Enums\PoolSeasonEnum;
+use App\Models\Campaign\CampaignGame;
 use App\Observers\GameObserver;
 use App\Traits\LogsCreationActivity;
 use Illuminate\Database\Eloquent\Attributes\ObservedBy;
@@ -114,6 +115,12 @@ class Game extends Model
     public function tournamentGame(): HasOne
     {
         return $this->hasOne(TournamentGame::class);
+    }
+
+    /** CampaignGame wrapper this tracker game was created for, if any. */
+    public function campaignGame(): HasOne
+    {
+        return $this->hasOne(CampaignGame::class, 'base_game_id');
     }
 
     public function playerOne(): ?GamePlayer

--- a/app/Observers/CustomCharacterObserver.php
+++ b/app/Observers/CustomCharacterObserver.php
@@ -74,7 +74,13 @@ class CustomCharacterObserver
     public function created(CustomCharacter $character): void
     {
         if ($character->is_campaign_leader || $character->is_campaign_totem) {
-            GenerateLeaderCardImage::dispatch($character->id);
+            // afterCommit(): every call site that creates/updates a Leader or
+            // Totem (Leader Builder, Advance Leader, Aftermath) does so inside
+            // DB::transaction. Queue connections here run with after_commit=false,
+            // so a worker can otherwise dequeue this before the transaction
+            // commits, fail to find the row, and silently no-op — the card
+            // then never renders and there's no retry to catch it.
+            GenerateLeaderCardImage::dispatch($character->id)->afterCommit();
         }
     }
 
@@ -88,6 +94,6 @@ class CustomCharacterObserver
             return;
         }
 
-        GenerateLeaderCardImage::dispatch($character->id);
+        GenerateLeaderCardImage::dispatch($character->id)->afterCommit();
     }
 }

--- a/resources/js/components/Game/GameCrewMemberDrawer.vue
+++ b/resources/js/components/Game/GameCrewMemberDrawer.vue
@@ -51,7 +51,12 @@ interface PreviewMember {
     back_image: string | null;
     notes?: string | null;
     attached_upgrades?: AttachedUpgrade[];
-    custom_character?: { actions: CustomCharacterAction[]; abilities: CustomCharacterAbility[] } | null;
+    custom_character?: {
+        actions: CustomCharacterAction[];
+        abilities: CustomCharacterAbility[];
+        front_image?: string | null;
+        back_image?: string | null;
+    } | null;
 }
 
 interface Miniature {
@@ -124,6 +129,13 @@ const currentSculptId = computed(() => {
     return String(match?.id ?? props.miniatures[0]?.id ?? '');
 });
 
+// Campaign Leader/Totem card art (pg 31, 52) lives on custom_character, not
+// the member's own front_image/back_image columns — those stay null for
+// custom rows (see GameSetupController::copyCrewToGame). Fall back to it so
+// the generated card renders once one exists, same as the inline expand view.
+const effectiveFrontImage = computed(() => props.member?.front_image ?? props.member?.custom_character?.front_image ?? null);
+const effectiveBackImage = computed(() => props.member?.back_image ?? props.member?.custom_character?.back_image ?? null);
+
 // Visual sculpt picker: dropdown is fast for keyboard users and power-users,
 // but picking by name alone is hard when half the sculpts share one. The
 // visual picker surfaces the card fronts in a scrollable grid.
@@ -171,12 +183,12 @@ const handleVisualPick = (miniatureId: number) => {
                         </Button>
                     </div>
                 </DrawerHeader>
-                <div v-if="member.front_image" class="px-4 pb-2">
+                <div v-if="effectiveFrontImage" class="px-4 pb-2">
                     <!-- Desktop: side-by-side combo view -->
                     <div class="hidden items-start justify-center gap-2 sm:flex">
                         <div class="relative">
                             <img
-                                :src="'/storage/' + member.front_image"
+                                :src="'/storage/' + effectiveFrontImage"
                                 :alt="member.display_name + ' front'"
                                 class="max-h-[65dvh] w-auto rounded-lg object-contain"
                             />
@@ -186,8 +198,8 @@ const handleVisualPick = (miniatureId: number) => {
                                 aria-label="View fullscreen"
                                 @click="
                                     emit('open-fullscreen', {
-                                        src: '/storage/' + member.front_image,
-                                        backSrc: member.back_image ? '/storage/' + member.back_image : null,
+                                        src: '/storage/' + effectiveFrontImage,
+                                        backSrc: effectiveBackImage ? '/storage/' + effectiveBackImage : null,
                                         title: member.display_name,
                                     })
                                 "
@@ -195,9 +207,9 @@ const handleVisualPick = (miniatureId: number) => {
                                 <Maximize2 class="size-3.5" />
                             </button>
                         </div>
-                        <div v-if="member.back_image" class="relative">
+                        <div v-if="effectiveBackImage" class="relative">
                             <img
-                                :src="'/storage/' + member.back_image"
+                                :src="'/storage/' + effectiveBackImage"
                                 :alt="member.display_name + ' back'"
                                 class="max-h-[65dvh] w-auto rounded-lg object-contain"
                             />
@@ -207,8 +219,8 @@ const handleVisualPick = (miniatureId: number) => {
                                 aria-label="View fullscreen"
                                 @click="
                                     emit('open-fullscreen', {
-                                        src: '/storage/' + member.back_image,
-                                        backSrc: '/storage/' + member.front_image,
+                                        src: '/storage/' + effectiveBackImage,
+                                        backSrc: '/storage/' + effectiveFrontImage,
                                         title: member.display_name,
                                     })
                                 "
@@ -220,20 +232,20 @@ const handleVisualPick = (miniatureId: number) => {
                     <!-- Mobile: flip card -->
                     <div class="flex min-h-0 flex-1 items-start justify-center sm:hidden [&_img]:max-h-[65dvh] [&_img]:w-auto [&_img]:object-contain">
                         <CharacterCardView
-                            :key="member.front_image"
+                            :key="effectiveFrontImage"
                             :miniature="{
                                 id: member.id,
                                 display_name: member.display_name,
                                 slug: '',
-                                front_image: member.front_image,
-                                back_image: member.back_image,
+                                front_image: effectiveFrontImage,
+                                back_image: effectiveBackImage,
                             }"
                             :show-link="false"
                             :show-collection="false"
                         />
                     </div>
                 </div>
-                <!-- No card art (Campaign Leader/Totem) — render the JSON stat block instead (pg 31, 52). -->
+                <!-- No card art (Campaign Leader/Totem, before an image is generated) — render the JSON stat block instead (pg 31, 52). -->
                 <div
                     v-else-if="member.custom_character && (member.custom_character.actions.length || member.custom_character.abilities.length)"
                     class="space-y-2 px-4 pb-2"

--- a/resources/js/components/Game/GameCrewSelectPanel.vue
+++ b/resources/js/components/Game/GameCrewSelectPanel.vue
@@ -45,6 +45,11 @@ interface CrewOption {
 }
 
 interface CampaignArsenalModel {
+    /** The CampaignArsenalModel row's own id — distinct per owned physical
+     *  copy, even when several share the same character_id. Selection state
+     *  keys off this, not character_id, so owning multiple copies of the
+     *  same catalog Character can be hired individually. */
+    id: number;
     character_id: number;
     name: string;
     faction: string;
@@ -89,8 +94,8 @@ const props = defineProps<{
 const emit = defineEmits<{
     /** Select a saved crew (parent owns the POST + reload). Body carries crew_build_id + slot. */
     confirm: [body: Record<string, unknown>];
-    /** Campaign games: confirm with selected arsenal character IDs + optional equipment assignments (pg 19). */
-    'confirm-campaign-crew': [characterIds: number[], equipmentAssignments: { equipment_id: number; target: string }[]];
+    /** Campaign games: confirm with selected CampaignArsenalModel row IDs + optional equipment assignments (pg 19). */
+    'confirm-campaign-crew': [arsenalModelIds: number[], equipmentAssignments: { equipment_id: number; target: string }[]];
     /** Skip the opponent's crew in solo setup, optionally locking in their title first. */
     'skip-opponent-crew': [titleDisplayName: string | null];
 }>();
@@ -166,25 +171,48 @@ const skipOpponentCrew = () => {
     emit('skip-opponent-crew', title?.display_name ?? null);
 };
 
+// Keyed by CampaignArsenalModel row id (not character_id) so owning several
+// copies of the same catalog Character — each its own arsenal row — can be
+// selected/hired individually instead of all copies toggling together.
 const selectedArsenalIds = ref<number[]>([]);
-const toggleArsenalModel = (characterId: number) => {
-    const idx = selectedArsenalIds.value.indexOf(characterId);
+const toggleArsenalModel = (arsenalModelId: number) => {
+    const idx = selectedArsenalIds.value.indexOf(arsenalModelId);
     if (idx >= 0) {
         selectedArsenalIds.value.splice(idx, 1);
     } else {
-        selectedArsenalIds.value.push(characterId);
+        selectedArsenalIds.value.push(arsenalModelId);
     }
 };
 const campaignTotalCost = computed(() =>
     selectedArsenalIds.value.reduce((sum, id) => {
-        const m = props.campaignArsenal.find((a) => a.character_id === id);
+        const m = props.campaignArsenal.find((a) => a.id === id);
         return sum + (m?.effective_cost ?? 0);
     }, 0),
 );
 const campaignOverBudget = computed(() => campaignTotalCost.value > props.game.encounter_size);
 
+// "(2/3)" copy-index suffix when the arsenal owns more than one of the same
+// catalog model — otherwise two identical-looking "Guild Guard" rows would
+// give no visual hint they're independently selectable owned copies.
+const campaignArsenalCopyLabel = computed(() => {
+    const totalByName: Record<string, number> = {};
+    for (const m of props.campaignArsenal) totalByName[m.name] = (totalByName[m.name] ?? 0) + 1;
+    const seen: Record<string, number> = {};
+    const labels: Record<number, string | null> = {};
+    for (const m of props.campaignArsenal) {
+        if (totalByName[m.name] <= 1) {
+            labels[m.id] = null;
+            continue;
+        }
+        seen[m.name] = (seen[m.name] ?? 0) + 1;
+        labels[m.id] = `${seen[m.name]}/${totalByName[m.name]}`;
+    }
+
+    return labels;
+});
+
 // Equipment assignment (pg 19): optional, one slot per owned copy. Value is
-// '__none__' (unassigned), 'leader', or a selected arsenal character_id as a string.
+// '__none__' (unassigned), 'leader', or a selected arsenal row id as a string.
 const equipmentTargets = ref<Record<string, string>>({});
 interface EquipmentSlot {
     key: string;
@@ -202,14 +230,32 @@ const equipmentSlots = computed<EquipmentSlot[]>(() =>
         })),
     ),
 );
-const equipmentTargetOptions = computed(() => [
-    { value: 'leader', label: 'Leader' },
-    ...(props.campaignTotem ? [{ value: 'totem', label: props.campaignTotem.name }] : []),
-    ...selectedArsenalIds.value.map((id) => ({
-        value: String(id),
-        label: props.campaignArsenal.find((a) => a.character_id === id)?.name ?? `#${id}`,
-    })),
-]);
+const equipmentTargetOptions = computed(() => {
+    // Disambiguate when the same catalog model is hired more than once this
+    // game (multiple selected arsenal rows sharing a name) — otherwise the
+    // dropdown would show two identical, unpickable-apart "Guild Guard" entries.
+    const nameCounts: Record<string, number> = {};
+    for (const id of selectedArsenalIds.value) {
+        const name = props.campaignArsenal.find((a) => a.id === id)?.name;
+        if (name) nameCounts[name] = (nameCounts[name] ?? 0) + 1;
+    }
+    const seen: Record<string, number> = {};
+
+    return [
+        { value: 'leader', label: 'Leader' },
+        ...(props.campaignTotem ? [{ value: 'totem', label: props.campaignTotem.name }] : []),
+        ...selectedArsenalIds.value.map((id) => {
+            const name = props.campaignArsenal.find((a) => a.id === id)?.name ?? `#${id}`;
+            if ((nameCounts[name] ?? 0) > 1) {
+                seen[name] = (seen[name] ?? 0) + 1;
+
+                return { value: String(id), label: `${name} (${seen[name]})` };
+            }
+
+            return { value: String(id), label: name };
+        }),
+    ];
+});
 // Drop any assignment whose target was deselected from the crew.
 watch(selectedArsenalIds, () => {
     const validTargets = new Set(['__none__', 'leader', 'totem', ...selectedArsenalIds.value.map(String)]);
@@ -288,17 +334,20 @@ const confirmCampaignCrew = () => {
                 <div v-if="campaignArsenal.length" class="space-y-1">
                     <div
                         v-for="m in campaignArsenal"
-                        :key="m.character_id"
+                        :key="m.id"
                         class="flex cursor-pointer items-center justify-between rounded-md border px-3 py-2 text-sm transition-colors"
-                        :class="selectedArsenalIds.includes(m.character_id) ? 'border-primary bg-primary/10' : 'hover:bg-muted/50'"
-                        @click="toggleArsenalModel(m.character_id)"
+                        :class="selectedArsenalIds.includes(m.id) ? 'border-primary bg-primary/10' : 'hover:bg-muted/50'"
+                        @click="toggleArsenalModel(m.id)"
                     >
                         <div class="flex min-w-0 items-center gap-2">
                             <div
                                 class="size-4 shrink-0 rounded border-2 transition-colors"
-                                :class="selectedArsenalIds.includes(m.character_id) ? 'border-primary bg-primary' : 'border-muted-foreground'"
+                                :class="selectedArsenalIds.includes(m.id) ? 'border-primary bg-primary' : 'border-muted-foreground'"
                             />
                             <span class="truncate font-medium">{{ m.name }}</span>
+                            <span v-if="campaignArsenalCopyLabel[m.id]" class="shrink-0 text-[10px] text-muted-foreground"
+                                >({{ campaignArsenalCopyLabel[m.id] }})</span
+                            >
                             <Badge
                                 v-if="m.is_ook"
                                 variant="outline"

--- a/resources/js/pages/Campaigns/Show.vue
+++ b/resources/js/pages/Campaigns/Show.vue
@@ -60,7 +60,31 @@ interface CampaignData {
     invitations: InvitationRow[];
 }
 
-const props = defineProps<{ campaign: CampaignData; is_organizer: boolean; all_arsenals_complete: boolean }>();
+interface ActiveSoloGame {
+    uuid: string;
+    status: string;
+    started_at: string | null;
+}
+
+const props = defineProps<{
+    campaign: CampaignData;
+    is_organizer: boolean;
+    all_arsenals_complete: boolean;
+    /** The player's own not-yet-finished live game for this solo campaign, if
+     *  one exists — lets the hub offer "Resume" instead of Play Live silently
+     *  orphaning it by minting a brand new game every click. */
+    active_solo_game: ActiveSoloGame | null;
+}>();
+
+const activeSoloGameStatusLabel = (status: string): string =>
+    (
+        {
+            master_select: 'Selecting Master',
+            crew_select: 'Selecting Crew',
+            scheme_select: 'Selecting Schemes',
+            in_progress: 'In Progress',
+        } as Record<string, string>
+    )[status] ?? status;
 
 const statusVariant = computed((): 'default' | 'outline' | 'destructive' | 'secondary' => {
     switch (props.campaign.status) {
@@ -234,7 +258,13 @@ const deleteCampaign = async (id: number) => {
                 Start Campaign
             </Button>
             <template v-if="campaign.status === 'active' && campaign.is_solo">
-                <Button @click="playLive(campaign.id)">Play Live</Button>
+                <template v-if="active_solo_game">
+                    <Link :href="route('games.show', active_solo_game.uuid)">
+                        <Button>Resume Game <Badge variant="secondary" class="ml-1.5 text-[10px]">{{ activeSoloGameStatusLabel(active_solo_game.status) }}</Badge></Button>
+                    </Link>
+                    <Button variant="outline" @click="playLive(campaign.id)">New Game</Button>
+                </template>
+                <Button v-else @click="playLive(campaign.id)">Play Live</Button>
                 <Link :href="route('campaigns.games.log', campaign.id)">
                     <Button variant="outline">Log Game</Button>
                 </Link>

--- a/resources/js/pages/Games/Show.vue
+++ b/resources/js/pages/Games/Show.vue
@@ -268,6 +268,9 @@ const props = defineProps<{
         crew_b_card: CampaignCrewCardPayload;
     } | null;
     campaign_arsenal?: {
+        /** The CampaignArsenalModel row's own id — distinct per owned physical
+         *  copy, even when several share the same character_id. */
+        id: number;
         character_id: number;
         name: string;
         faction: string;
@@ -1358,6 +1361,17 @@ const myActiveUpgradeId = computed(() => myPlayer.value?.active_crew_upgrade_id 
 const opponentActiveUpgradeId = computed(() => opponent.value?.active_crew_upgrade_id ?? opponent.value?.crew_build?.crew_upgrade_id ?? null);
 const myUpgradeMode = computed(() => myPlayer.value?.master?.crew_upgrade_mode ?? 'select_one');
 const opponentUpgradeMode = computed(() => opponent.value?.master?.crew_upgrade_mode ?? 'select_one');
+
+// Campaign Crew Card effect (pg 17, 32, 54) — starter + any Tier-4 borrowed
+// effects. campaign_context.crew_a always belongs to slot 1 (see
+// GameController::buildCampaignContext), so "my" side follows mySlot rather
+// than always being crew_a — the opponent in a duel campaign game is slot 2
+// looking at the same payload from their own perspective.
+const myCrewCard = computed<CampaignCrewCardPayload | null>(() => {
+    if (!isCampaign.value || !props.campaign_context) return null;
+    return mySlot.value === 1 ? props.campaign_context.crew_a_card : props.campaign_context.crew_b_card;
+});
+const expandedMyCrewCardEffect = ref(false);
 
 const swapCrewUpgrade = async (upgradeId: number, slot?: number) => {
     const payload: Record<string, any> = { active_crew_upgrade_id: upgradeId };
@@ -3356,7 +3370,10 @@ const isPastStep = (step: string) => statusOrder.indexOf(props.game.status) > st
                 @confirm="(body) => postSetup(route('games.setup.crew', game.uuid), body)"
                 @confirm-campaign-crew="
                     (ids, equipmentAssignments) =>
-                        postSetup(route('games.setup.campaign-crew', game.uuid), { character_ids: ids, equipment_assignments: equipmentAssignments })
+                        postSetup(route('games.setup.campaign-crew', game.uuid), {
+                            arsenal_model_ids: ids,
+                            equipment_assignments: equipmentAssignments,
+                        })
                 "
                 @skip-opponent-crew="onSkipOpponentCrew"
             />
@@ -4320,6 +4337,78 @@ const isPastStep = (step: string) => statusOrder.indexOf(props.game.status) > st
                                             :alt-text="upgrade.name"
                                             :show-link="false"
                                         />
+                                    </div>
+                                </Transition>
+                            </div>
+                        </div>
+                        <!-- Campaign Crew Card (pg 17, 32, 54) — starter + any Tier-4 borrowed effects.
+                             Same reference-row treatment as Reference Upgrades above: crew-level, not
+                             tied to a specific model, so it lives above the member list rather than
+                             only in the top campaign banner. -->
+                        <div v-if="isCampaign && myCrewCard?.effect" class="mb-2 space-y-1">
+                            <div class="rounded-md border border-border/50 bg-accent/30 px-2 py-1.5 text-sm">
+                                <div class="flex items-center gap-1.5">
+                                    <Star class="size-3.5 shrink-0 text-muted-foreground" />
+                                    <span class="flex-1 font-semibold">{{ myCrewCard.effect.name }}</span>
+                                    <Badge variant="outline" class="px-1.5 py-0 text-[9px]">Crew Card</Badge>
+                                    <button
+                                        type="button"
+                                        class="rounded p-0.5 text-muted-foreground hover:text-foreground"
+                                        :title="expandedMyCrewCardEffect ? 'Collapse card' : 'Expand card'"
+                                        @click="expandedMyCrewCardEffect = !expandedMyCrewCardEffect"
+                                    >
+                                        <ChevronDown class="size-3.5 transition-transform" :class="expandedMyCrewCardEffect ? 'rotate-180' : ''" />
+                                    </button>
+                                </div>
+                                <Transition
+                                    enter-active-class="transition-all duration-300 ease-out"
+                                    leave-active-class="transition-all duration-200 ease-in"
+                                    enter-from-class="max-h-0 opacity-0"
+                                    enter-to-class="max-h-[600px] opacity-100"
+                                    leave-from-class="max-h-[600px] opacity-100"
+                                    leave-to-class="max-h-0 opacity-0"
+                                >
+                                    <div v-if="expandedMyCrewCardEffect" class="mt-2 space-y-2 overflow-hidden">
+                                        <p v-if="myCrewCard.effect.body" class="text-xs leading-relaxed text-muted-foreground">
+                                            <GameText :text="myCrewCard.effect.body" />
+                                        </p>
+                                        <ActionCard
+                                            v-for="(a, i) in myCrewCard.effect.actions"
+                                            :key="`mycc-action-${i}`"
+                                            :action="a"
+                                            :hide-footer="true"
+                                        />
+                                        <AbilityCard
+                                            v-for="(ab, i) in myCrewCard.effect.abilities"
+                                            :key="`mycc-ability-${i}`"
+                                            :ability="ab"
+                                            :hide-footer="true"
+                                        />
+                                        <template v-for="adv in myCrewCard.borrowed" :key="`mycc-borrowed-${adv.id}`">
+                                            <div v-if="adv.effect" class="border-t pt-2">
+                                                <p class="text-xs font-medium">
+                                                    {{ adv.effect.name }}
+                                                    <span v-if="adv.source_master_name" class="text-muted-foreground"
+                                                        >— borrowed from {{ adv.source_master_name }}</span
+                                                    >
+                                                </p>
+                                                <p v-if="adv.effect.body" class="text-xs leading-relaxed text-muted-foreground">
+                                                    <GameText :text="adv.effect.body" />
+                                                </p>
+                                                <ActionCard
+                                                    v-for="(a, i) in adv.effect.actions"
+                                                    :key="`mycc-badv-action-${adv.id}-${i}`"
+                                                    :action="a"
+                                                    :hide-footer="true"
+                                                />
+                                                <AbilityCard
+                                                    v-for="(ab, i) in adv.effect.abilities"
+                                                    :key="`mycc-badv-ability-${adv.id}-${i}`"
+                                                    :ability="ab"
+                                                    :hide-footer="true"
+                                                />
+                                            </div>
+                                        </template>
                                     </div>
                                 </Transition>
                             </div>

--- a/tests/Feature/Campaign/CampaignGameIntegrationTest.php
+++ b/tests/Feature/Campaign/CampaignGameIntegrationTest.php
@@ -377,11 +377,11 @@ it('submitCampaignCrew copies the selected arsenal models into game_crew_members
     ]);
 
     $hired = Character::factory()->create(['cost' => 6, 'faction' => FactionEnum::Arcanists->value]);
-    CampaignArsenalModel::factory()->create(['campaign_crew_id' => $crewA->id, 'character_id' => $hired->id]);
+    $arsenalModel = CampaignArsenalModel::factory()->create(['campaign_crew_id' => $crewA->id, 'character_id' => $hired->id]);
 
     $this->actingAs($userA)
         ->postJson(route('games.setup.campaign-crew', $game->uuid), [
-            'character_ids' => [$hired->id],
+            'arsenal_model_ids' => [$arsenalModel->id],
         ])
         ->assertOk();
 
@@ -391,6 +391,55 @@ it('submitCampaignCrew copies the selected arsenal models into game_crew_members
         ->toContain($hired->display_name)
         ->and(\App\Models\GameCrewMember::where('game_id', $game->id)->where('game_player_id', $player->id)->where('hiring_category', 'leader')->exists())
         ->toBeTrue();
+});
+
+it('submitCampaignCrew hires exactly the selected arsenal row when the crew owns several copies of the same model', function () {
+    [$userA, , , $crewA, , $game] = campaignGameSetup();
+
+    CustomCharacter::create([
+        'user_id' => $userA->id,
+        'campaign_crew_id' => $crewA->id,
+        'is_campaign_leader' => true,
+        'current' => true,
+        'share_code' => 'ldr-test-006',
+        'name' => 'Mortimer Vance',
+        'display_name' => 'Mortimer Vance',
+        'slug' => 'mortimer-vance-6',
+        'faction' => FactionEnum::Arcanists->value,
+        'health' => 14, 'defense' => 5, 'willpower' => 5, 'speed' => 6,
+    ]);
+
+    // Three separate owned copies of the same catalog model — each its own
+    // CampaignArsenalModel row (no count column; that's how ownership of
+    // multiples is represented). Only one gets injured.
+    $hired = Character::factory()->create(['cost' => 6, 'faction' => FactionEnum::Arcanists->value]);
+    $copy1 = CampaignArsenalModel::factory()->create(['campaign_crew_id' => $crewA->id, 'character_id' => $hired->id]);
+    $copy2 = CampaignArsenalModel::factory()->create(['campaign_crew_id' => $crewA->id, 'character_id' => $hired->id]);
+    CampaignArsenalModel::factory()->create(['campaign_crew_id' => $crewA->id, 'character_id' => $hired->id]);
+
+    $injury = \App\Models\Upgrade::factory()->campaignInjury()->create(['name' => 'Broken Arm']);
+    \App\Models\Campaign\CampaignArsenalModelInjury::create([
+        'campaign_arsenal_model_id' => $copy2->id,
+        'injury_upgrade_id' => $injury->id,
+    ]);
+
+    // Hire only copy1 — not "every copy of Guild Guard the crew owns".
+    $this->actingAs($userA)
+        ->postJson(route('games.setup.campaign-crew', $game->uuid), [
+            'arsenal_model_ids' => [$copy1->id],
+        ])
+        ->assertOk();
+
+    $player = $game->players()->where('user_id', $userA->id)->first();
+    $hiredMembers = \App\Models\GameCrewMember::where('game_id', $game->id)
+        ->where('game_player_id', $player->id)
+        ->where('display_name', $hired->display_name)
+        ->get();
+
+    // Exactly one hire, not three.
+    expect($hiredMembers)->toHaveCount(1);
+    // And it's copy1's injuries that carried over, not copy2's or copy3's.
+    expect(collect($hiredMembers->first()->attached_upgrades)->pluck('name')->all())->toBe([]);
 });
 
 it('Games/Show exposes the Campaign Leader\'s actions/abilities via custom_character, since it has no card art', function () {
@@ -412,7 +461,7 @@ it('Games/Show exposes the Campaign Leader\'s actions/abilities via custom_chara
     ]);
 
     $this->actingAs($userA)
-        ->postJson(route('games.setup.campaign-crew', $game->uuid), ['character_ids' => []])
+        ->postJson(route('games.setup.campaign-crew', $game->uuid), ['arsenal_model_ids' => []])
         ->assertOk();
 
     $game->update(['status' => GameStatusEnum::InProgress->value]);
@@ -459,7 +508,7 @@ it('submitCampaignCrew carries injuries from a previous aftermath onto the leade
 
     $this->actingAs($userA)
         ->postJson(route('games.setup.campaign-crew', $game->uuid), [
-            'character_ids' => [$hired->id],
+            'arsenal_model_ids' => [$arsenalModel->id],
         ])
         ->assertOk();
 
@@ -490,16 +539,16 @@ it('submitCampaignCrew assigns owned equipment to the Leader or a specific hire 
     ]);
 
     $hired = Character::factory()->create(['cost' => 6, 'faction' => FactionEnum::Arcanists->value]);
-    CampaignArsenalModel::factory()->create(['campaign_crew_id' => $crewA->id, 'character_id' => $hired->id]);
+    $arsenalModel = CampaignArsenalModel::factory()->create(['campaign_crew_id' => $crewA->id, 'character_id' => $hired->id]);
 
     $equipmentUpgrade = \App\Models\Upgrade::factory()->campaignEquipment()->create(['name' => 'Owned Trinket']);
     \App\Models\Campaign\CampaignEquipment::factory()->create(['campaign_crew_id' => $crewA->id, 'equipment_upgrade_id' => $equipmentUpgrade->id]);
 
     $this->actingAs($userA)
         ->postJson(route('games.setup.campaign-crew', $game->uuid), [
-            'character_ids' => [$hired->id],
+            'arsenal_model_ids' => [$arsenalModel->id],
             'equipment_assignments' => [
-                ['equipment_id' => $equipmentUpgrade->id, 'target' => (string) $hired->id],
+                ['equipment_id' => $equipmentUpgrade->id, 'target' => (string) $arsenalModel->id],
             ],
         ])
         ->assertOk();
@@ -522,7 +571,7 @@ it('submitCampaignCrew rejects an equipment_assignments target outside the Leade
 
     $this->actingAs($userA)
         ->postJson(route('games.setup.campaign-crew', $game->uuid), [
-            'character_ids' => [],
+            'arsenal_model_ids' => [],
             'equipment_assignments' => [
                 ['equipment_id' => $equipmentUpgrade->id, 'target' => (string) $notHired->id],
             ],
@@ -553,7 +602,7 @@ it('submitCampaignCrew assigns owned equipment to a Tier-3 Totem', function () {
 
     $this->actingAs($userA)
         ->postJson(route('games.setup.campaign-crew', $game->uuid), [
-            'character_ids' => [],
+            'arsenal_model_ids' => [],
             'equipment_assignments' => [
                 ['equipment_id' => $equipmentUpgrade->id, 'target' => 'totem'],
             ],
@@ -578,7 +627,7 @@ it('submitCampaignCrew rejects a totem equipment assignment when the crew has no
 
     $this->actingAs($userA)
         ->postJson(route('games.setup.campaign-crew', $game->uuid), [
-            'character_ids' => [],
+            'arsenal_model_ids' => [],
             'equipment_assignments' => [
                 ['equipment_id' => $equipmentUpgrade->id, 'target' => 'totem'],
             ],
@@ -593,8 +642,8 @@ it('submitCampaignCrew rejects assigning more copies of an equipment than the cr
 
     $hiredA = Character::factory()->create(['cost' => 6, 'faction' => FactionEnum::Arcanists->value]);
     $hiredB = Character::factory()->create(['cost' => 6, 'faction' => FactionEnum::Arcanists->value]);
-    CampaignArsenalModel::factory()->create(['campaign_crew_id' => $crewA->id, 'character_id' => $hiredA->id]);
-    CampaignArsenalModel::factory()->create(['campaign_crew_id' => $crewA->id, 'character_id' => $hiredB->id]);
+    $arsenalModelA = CampaignArsenalModel::factory()->create(['campaign_crew_id' => $crewA->id, 'character_id' => $hiredA->id]);
+    $arsenalModelB = CampaignArsenalModel::factory()->create(['campaign_crew_id' => $crewA->id, 'character_id' => $hiredB->id]);
 
     // Only one copy owned.
     $equipmentUpgrade = \App\Models\Upgrade::factory()->campaignEquipment()->create();
@@ -602,10 +651,10 @@ it('submitCampaignCrew rejects assigning more copies of an equipment than the cr
 
     $this->actingAs($userA)
         ->postJson(route('games.setup.campaign-crew', $game->uuid), [
-            'character_ids' => [$hiredA->id, $hiredB->id],
+            'arsenal_model_ids' => [$arsenalModelA->id, $arsenalModelB->id],
             'equipment_assignments' => [
-                ['equipment_id' => $equipmentUpgrade->id, 'target' => (string) $hiredA->id],
-                ['equipment_id' => $equipmentUpgrade->id, 'target' => (string) $hiredB->id],
+                ['equipment_id' => $equipmentUpgrade->id, 'target' => (string) $arsenalModelA->id],
+                ['equipment_id' => $equipmentUpgrade->id, 'target' => (string) $arsenalModelB->id],
             ],
         ])
         ->assertStatus(422);
@@ -668,7 +717,7 @@ it('solo Campaign setup auto-fills a generic opponent — no opponent faction/ma
     // Player 1 confirms their campaign crew alone — opponent auto-skips too,
     // advancing straight to Scheme Select with no further interaction needed.
     $this->actingAs($user)
-        ->postJson(route('games.setup.campaign-crew', $game->uuid), ['character_ids' => []])
+        ->postJson(route('games.setup.campaign-crew', $game->uuid), ['arsenal_model_ids' => []])
         ->assertOk()
         ->assertJson(['both_done' => true]);
 

--- a/tests/Feature/Campaign/CampaignSeederTest.php
+++ b/tests/Feature/Campaign/CampaignSeederTest.php
@@ -145,9 +145,9 @@ it('solo campaign game returns leader and arsenal via faction fallback when no C
         );
 
     // submitCampaignCrew accepts picks from the arsenal.
-    $firstCharId = $crew->arsenalModels()->active()->value('character_id');
+    $firstArsenalModelId = $crew->arsenalModels()->active()->value('id');
     test()->actingAs($user)
-        ->postJson(route('games.setup.campaign-crew', $game->uuid), ['character_ids' => [$firstCharId]])
+        ->postJson(route('games.setup.campaign-crew', $game->uuid), ['arsenal_model_ids' => [$firstArsenalModelId]])
         ->assertOk()
         ->assertJson(['success' => true]);
 });

--- a/tests/Feature/Campaign/SoloCampaignTest.php
+++ b/tests/Feature/Campaign/SoloCampaignTest.php
@@ -372,6 +372,48 @@ it('playLive starts a live game with an eagerly-linked CampaignGame row', functi
         ->and((int) $wrap->week_number)->toBe(3);
 });
 
+it('Campaigns/Show exposes active_solo_game once Play Live has been clicked, so the hub can offer Resume', function () {
+    $user = soloUser();
+    $campaign = Campaign::factory()->create([
+        'organizer_user_id' => $user->id,
+        'status' => CampaignStatusEnum::Active,
+        'is_solo' => true,
+    ]);
+    CampaignPlayer::factory()->organizer()->create(['campaign_id' => $campaign->id, 'user_id' => $user->id]);
+    CampaignCrew::factory()->create([
+        'campaign_id' => $campaign->id,
+        'user_id' => $user->id,
+        'faction' => \App\Enums\FactionEnum::Arcanists->value,
+    ]);
+
+    // No game yet — hub should not offer a resume option.
+    $this->actingAs($user)
+        ->get(route('campaigns.show', $campaign))
+        ->assertOk()
+        ->assertInertia(fn ($page) => $page->where('active_solo_game', null));
+
+    $this->actingAs($user)->post(route('campaigns.games.play', $campaign))->assertRedirect();
+    $game = \App\Models\Game::query()->where('creator_id', $user->id)->latest('id')->firstOrFail();
+
+    // Not finished yet — hub should surface it for Resume.
+    $this->actingAs($user)
+        ->get(route('campaigns.show', $campaign))
+        ->assertOk()
+        ->assertInertia(fn ($page) => $page
+            ->where('active_solo_game.uuid', $game->uuid)
+            ->where('active_solo_game.status', 'master_select')
+        );
+
+    // Once finished, it's no longer "active" — a fresh Play Live click should
+    // mint a new game rather than offering to resume a completed one.
+    $game->update(['status' => \App\Enums\GameStatusEnum::Completed->value]);
+
+    $this->actingAs($user)
+        ->get(route('campaigns.show', $campaign))
+        ->assertOk()
+        ->assertInertia(fn ($page) => $page->where('active_solo_game', null));
+});
+
 it('playLive 404s on a non-solo campaign', function () {
     $user = soloUser();
     $campaign = Campaign::factory()->create([


### PR DESCRIPTION
…card row, solo game resume

- Leader/Totem card images could silently never regenerate on edit: the regen job was dispatched inside a DB transaction with after_commit=false, so a worker could race the commit and no-op. Dispatch ->afterCommit() now.
- GameCrewMemberDrawer fell back to the JSON stat block instead of showing a generated Leader/Totem card image, since it only checked the member's own (always-null) front_image column instead of custom_character's.
- Campaign Arsenal crew-select collapsed every owned copy of the same catalog model into a single toggle (keyed by character_id), so hiring one hired all of them with no way to pick individually. Replumbed the picker, wire payload, and copyCrewToGame to key off each arsenal row's own id instead.
- Added a Crew Card reference row to "Your Crew" (mirrors Standard's Reference Upgrades), since the campaign Crew Card effect previously only lived in the top banner toggle.
- Solo campaign "Play Live" minted a brand new game on every click, orphaning whatever was in progress. The campaign hub now tracks the player's active (not finished) game and offers Resume vs. New Game.